### PR TITLE
Increase contrast for symbols (issue #120)

### DIFF
--- a/src/renderer/leaflet/Symbol.js
+++ b/src/renderer/leaflet/Symbol.js
@@ -33,7 +33,9 @@ const modifiers = feature => Object.entries(feature.properties)
 const symbolOptions = feature => ({
   standard: {
     size: 34,
-    colorMode: 'Light', // default: light
+    colorMode: 'Light', // default: light,
+    outlineColor: 'white',
+    outlineWidth: 4, // this makes the text more readable on dark mode maps,
     ...modifiers(feature)
   },
   highlighted: {

--- a/src/renderer/leaflet/TACGRP/TACGRP.C2GM.GNL.LNE.BNDS.js
+++ b/src/renderer/leaflet/TACGRP/TACGRP.C2GM.GNL.LNE.BNDS.js
@@ -20,13 +20,17 @@ L.Feature['G*G*GLB---'] = L.Feature.Polyline.extend({
   createShape (options) {
     const id = uuid()
     const group = L.SVG.create('g')
-    const outlinePath = L.SVG.path({ 'stroke-width': 10, stroke: 'black', fill: 'none', 'opacity': 0.0 })
+    // clickable margin around the line
+    const marginPath = L.SVG.path({ 'stroke-width': 10, stroke: 'yellow', fill: 'none', 'opacity': 0.0 })
+    const outlinePath = L.SVG.path({ 'stroke-width': 5, stroke: 'white', fill: 'none', 'opacity': 1.0, mask: `url(#mask-${id})` })
     const linePath = L.SVG.path({ 'stroke-width': 3, stroke: 'black', fill: 'none', mask: `url(#mask-${id})` })
 
     // TODO: check flag options.interactive
+    L.DomUtil.addClass(marginPath, 'leaflet-interactive')
     L.DomUtil.addClass(outlinePath, 'leaflet-interactive')
     L.DomUtil.addClass(linePath, 'leaflet-interactive')
 
+    group.appendChild(marginPath)
     group.appendChild(outlinePath)
     group.appendChild(linePath)
 
@@ -68,6 +72,9 @@ L.Feature['G*G*GLB---'] = L.Feature.Polyline.extend({
           group.appendChild(label)
 
           // Create black mask for clipping:
+          /*
+          The color of the masking shape defines the opacity of the shape that uses the mask. The closer the color of the masking shape is to #ffffff (white), the more opaque the shape using the mask will be. The closer the color of the masking shape is to #000000 (black), the more transparent the shape using the mask will be
+          */
           const bbox = L.SVG.inflate(label.getBBox(), 8)
           const blackMask = L.SVG.rect({
             fill: 'black',
@@ -90,6 +97,7 @@ L.Feature['G*G*GLB---'] = L.Feature.Polyline.extend({
         this.options.lineSmoothing
       )
 
+      marginPath.setAttribute('d', d)
       outlinePath.setAttribute('d', d)
       linePath.setAttribute('d', d)
 

--- a/src/renderer/leaflet/TACGRP/TACGRP.C2GM.js
+++ b/src/renderer/leaflet/TACGRP/TACGRP.C2GM.js
@@ -277,7 +277,7 @@ L.Feature['G*G*GAY---'] = (feature, options) => {
   return new L.Feature.PolygonArea(feature, renderOptions, options)
 }
 
-const missleEnganementZone = name => (feature, options) => {
+const missleEngagementZone = name => (feature, options) => {
   const renderOptions = {
     styles: feature => ({ ...styles(feature), clipping: 'mask' }),
     labels: feature => centerLabelLeft([
@@ -294,9 +294,9 @@ const missleEnganementZone = name => (feature, options) => {
 }
 
 
-L.Feature['G*G*AAM---'] = missleEnganementZone('MEZ')
-L.Feature['G*G*AAML--'] = missleEnganementZone('LOMEZ')
-L.Feature['G*G*AAMH--'] = missleEnganementZone('HIMEZ')
+L.Feature['G*G*AAM---'] = missleEngagementZone('MEZ')
+L.Feature['G*G*AAML--'] = missleEngagementZone('LOMEZ')
+L.Feature['G*G*AAMH--'] = missleEngagementZone('HIMEZ')
 
 // Weapons Free Zone
 L.Feature['G*G*AAW---'] = (feature, options) => {


### PR DESCRIPTION
I've added a thin outline to
* symbols 
* boundaries
* areas
to increase the contrast on maps with a dark background (i.e. ortho.photos). The outline is usually black, for black lines (like boundaries) it is white.