### PR TITLE
check if browserWindow exists

### DIFF
--- a/src/main/menu/projects-menu.js
+++ b/src/main/menu/projects-menu.js
@@ -5,7 +5,10 @@ const menu = {
     {
       label: 'Manage Projects...',
       accelerator: 'CmdOrCtrl+Alt+M',
-      click: (menuItem, browserWindow) => browserWindow.send('IPC_SHOW_PROJECT_MANAGEMENT')
+      click: (menuItem, browserWindow) => {
+        /* browserWindow is undefined if minimized or closed */
+        if (browserWindow) browserWindow.send('IPC_SHOW_PROJECT_MANAGEMENT')
+      }
     }
   ]
 }


### PR DESCRIPTION
when the main windows is closed or minimized the user may still choose "manage projects" from the main menu. This triggers ipcMain.send on an undefined BrowserWindow instance.
The fix checks if the BrowserWindow exists.