### PR TITLE
quit the app if all windows are closed

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -23,7 +23,3 @@ app.allowRendererProcessReuse = false // `false` also removes deprecation messag
 const buildApplicationMenu = () => Menu.setApplicationMenu(buildFromTemplate(settings))
 buildApplicationMenu()
 bootstrap()
-
-app.on('window-all-closed', () => {
-  if (process.platform !== 'darwin') app.quit()
-})


### PR DESCRIPTION
Electron's default behavior is to quit the app when all windows are closed. The previous version of ODIN consumed the event ```window-all-closed``` and prevented this behavior - at least on OS-X (Darwin).

This PR reestablishes the default on all platforms.