### PR TITLE
show the project name in OSD

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -6,6 +6,7 @@ import Map from './map/Map'
 import Management from './components/Management'
 
 import { ipcRenderer, remote } from 'electron'
+import evented from './evented'
 
 const App = (props) => {
   const { classes } = props
@@ -26,6 +27,12 @@ const App = (props) => {
 
   React.useEffect(() => {
     if (!showManagement && currentProjectPath) {
+      /*  When a project gets renamed the window title is set accordingly.
+          Since we use the current window for reading the project path
+          we can also do so for the project name.
+      */
+      const projectName = remote.getCurrentWindow().getTitle()
+      evented.emit('OSD_MESSAGE', { message: projectName, slot: 'A1' })
       /*
         loading map tiles and features takes some time, so we
         create the preview of the map after 1s

--- a/src/renderer/project.js
+++ b/src/renderer/project.js
@@ -1,4 +1,4 @@
-import { ipcRenderer, remote } from 'electron'
+import { remote } from 'electron'
 import fs from 'fs'
 import path from 'path'
 import { List } from 'immutable'
@@ -72,11 +72,11 @@ const openProject = project => {
   if (currentProject) closeProject()
   currentProject = project
 
+  const projectName = remote.getCurrentWindow().getTitle()
+  const updateProject = () => evented.emit('OSD_MESSAGE', { message: projectName, slot: 'A1' })
   // NOTE: Defer message, so OSD has a chance to register event handler:
-  const updateProject = () =>
-    evented.emit('OSD_MESSAGE', { message: path.basename(project), slot: 'A1' })
-
   setTimeout(updateProject, 0)
+
   loadPreferences()
   listeners.forEach(listener => listener('open'))
 }
@@ -95,10 +95,7 @@ const layerFiles = () => {
     .map(filename => path.join(dir, filename))
 }
 
-
-
 window.addEventListener('beforeunload', () => closeProject())
-ipcRenderer.on('IPC_OPEN_PROJECT', (_, [project]) => openProject(project))
 
 // Wait until next tick for other components to be ready:
 setTimeout(() => {


### PR DESCRIPTION
fixes:
#240 (project name not displayed in OSD after rename)
#239 (OSD should show the name of the current project)