### PR TITLE
add edit menu to support common edit actions

### DIFF
--- a/src/main/menu/edit-menu.js
+++ b/src/main/menu/edit-menu.js
@@ -1,0 +1,25 @@
+const menu = {
+  label: 'Edit',
+  submenu: [
+    { role: 'undo' },
+    { role: 'redo' },
+    { type: 'separator' },
+    { role: 'cut' },
+    { role: 'copy' },
+    { role: 'paste' },
+    { role: 'pasteandmatchstyle' },
+    { role: 'delete' },
+    { role: 'selectall' }
+
+    // darwin: automatically added:
+    // 1. separator (see below)
+    // 2. start dictation
+    // 3. emojis & symbols
+  ]
+}
+
+if (process.platform === 'darwin') {
+  menu.submenu.push({ type: 'separator' })
+}
+
+export default menu

--- a/src/main/menu/menu.js
+++ b/src/main/menu/menu.js
@@ -3,7 +3,7 @@ import applicationMenu from './application-menu'
 import projectsMenu from './projects-menu'
 import viewMenu from './view-menu'
 import windowMenu from './window-menu'
-// import editMenu from './edit-menu'
+import editMenu from './edit-menu'
 // import helpMenu from './help-menu'
 // import goMenu from './go-menu'
 
@@ -11,7 +11,7 @@ const template = settings => ([
   // darwin only (must be filtered for other platforms)
   applicationMenu,
   projectsMenu,
-  // editMenu,
+  editMenu,
   viewMenu(settings),
   // goMenu,
   windowMenu


### PR DESCRIPTION
Common actions like
* select all
* cut
* copy
* paste
* undo
* redo

are only available if the edit menu and the appropriate roles are added to the application.
closes #246 