### PR TITLE
project management UI with media query

### DIFF
--- a/src/renderer/components/Management.js
+++ b/src/renderer/components/Management.js
@@ -25,7 +25,14 @@ const useStyles = makeStyles(theme => ({
     gridTemplateColumns: '1fr 2fr',
     gridTemplateRows: 'auto',
     gridGap: '1em',
-    gridTemplateAreas: '"projects details"'
+    gridTemplateAreas: '"projects details"',
+    '@media (max-width:1024px)': {
+      gridTemplateColumns: '1fr',
+      gridTemplateRows: 'auto auto',
+      gridTemplateAreas: `
+      "projects"
+      "details"`
+    }
   },
 
   sidebar: {


### PR DESCRIPTION
In order to allow smaller screen sizes without resulting in a more ugly layout the project management page uses a breakpoint at 1024 px. Screens up to 1024 px uses one column and two rows whereas bigger screens use two columns and one row for the areas "projects" and "details/preview".