### PR TITLE
projects are ordered by their lastAccess date

### DIFF
--- a/src/main/bootstrap.js
+++ b/src/main/bootstrap.js
@@ -91,7 +91,8 @@ const createProjectWindow = async (options) => {
 
     /* (re)establish electron's normal "quit the app if no more windows are open" behavior */
     appShallQuit = true
-
+    /* allow users to find their recently used projects access by data/time */
+    projects.mergeMetadata(projectOptions.path, { lastAccess: new Date() })
     window.loadURL(windowUrl)
   }
 

--- a/src/renderer/components/Management.js
+++ b/src/renderer/components/Management.js
@@ -12,6 +12,7 @@ import BackToMapIcon from '@material-ui/icons/ExitToApp'
 
 import { ipcRenderer, remote } from 'electron'
 import projects from '../../shared/projects'
+import { fromISO } from '../../shared/militaryTime'
 
 
 const useStyles = makeStyles(theme => ({
@@ -90,12 +91,20 @@ const Management = props => {
   /* reloadProject forces the enumerateProjects to re-run */
   const [reloadProjects, setReloadProjects] = React.useState(true)
 
+  const byName = (one, other) => {
+    if (one.metadata.lastAccess < other.metadata.lastAccess) return -1
+    if (one.metadata.lastAccess > other.metadata.lastAccess) return 1
+    return 0
+  }
+
 
   React.useEffect(() => {
     projects.enumerateProjects().then(allProjects => {
       /* read all metadata */
       Promise.all(
         allProjects.map(projectPath => projects.readMetadata(projectPath)))
+        .then(projects => projects.sort(byName))
+        .then(projects => projects.reverse())
         .then(augmentedProjects => {
           setReloadProjects(false)
           setCurrentProjects(augmentedProjects)
@@ -130,6 +139,11 @@ const Management = props => {
 
   const handleNewProject = () => {
     projects.createProject().then((_) => {
+      /*
+        an undefined focused project will select the first
+        project in the list
+      */
+      setFocusAndLoadPreview(undefined)
       setReloadProjects(true)
     })
   }
@@ -261,7 +275,7 @@ const Management = props => {
     const { projects } = props
     const items = projects.map(project => (
       <ListItem alignItems="flex-start" key={project.path} button onClick={ () => handleProjectFocus(project) }>
-        <ListItemText primary={project.metadata.name}/>
+        <ListItemText primary={project.metadata.name} secondary={`last access ${fromISO(project.metadata.lastAccess)}`}/>
         <Button id={'switchTo' + project.metadata.name} color="primary" variant="outlined" disabled={currentProjectPath === project.path}
           onClick={ () => handleProjectSelected(project)} startIcon={<PlayCircleOutlineIcon />} >
           Switch to

--- a/src/shared/militaryTime.js
+++ b/src/shared/militaryTime.js
@@ -30,11 +30,28 @@ const milTimeZones = {
 
 const MIL_DATE_FORMAT = 'ddHHmm--LLLyy'
 
-const getCurrentDateTime = () => {
-  const currentTime = DateTime.local()
-  const offset = Math.floor(currentTime.offset / 60)
+/**
+ *
+ * @param {*} date a Luxon DateTime object
+ */
+const toMilitaryTime = date => {
+  const offset = Math.floor(date.offset / 60)
   const offsetAsString = (offset >= 0) ? `+${offset}` : `-${offset}`
-  return currentTime.toFormat(MIL_DATE_FORMAT).toLowerCase().replace('--', milTimeZones[offsetAsString])
+  return date.toFormat(MIL_DATE_FORMAT).toLowerCase().replace('--', milTimeZones[offsetAsString])
+}
+
+const getCurrentDateTime = () => {
+  return toMilitaryTime(DateTime.local())
+}
+
+/**
+ *
+ * @param {*} isoDateString Military DateTime from an ISO 8601 string
+ * @returns the military date format
+ */
+export const fromISO = isoDateString => {
+  const date = DateTime.fromISO(isoDateString)
+  return toMilitaryTime(date)
 }
 
 export default getCurrentDateTime

--- a/src/shared/projects.js
+++ b/src/shared/projects.js
@@ -13,9 +13,10 @@ const ODIN_PROJECTS = path.join(ODIN_HOME, 'projects')
 const ODIN_LAYERS = 'layers'
 const ODIN_METADATA = 'metadata.json'
 const ODIN_PREVIEW = 'preview.jpg'
-const ODIN_DEFAULT_METADATA = {
-  name: 'untitled project'
-}
+const ODIN_DEFAULT_METADATA = () => ({
+  name: 'untitled project',
+  lastAccess: new Date()
+})
 
 const exists = projectPath => fs.existsSync(projectPath)
 
@@ -24,7 +25,7 @@ const createProject = async (name = uuid()) => {
   if (exists(projectPath)) return
   /* create subfolder structure, too */
   await fs.promises.mkdir(path.join(projectPath, ODIN_LAYERS), { recursive: true })
-  await fs.promises.writeFile(path.join(projectPath, ODIN_METADATA), JSON.stringify(ODIN_DEFAULT_METADATA))
+  await fs.promises.writeFile(path.join(projectPath, ODIN_METADATA), JSON.stringify(ODIN_DEFAULT_METADATA()))
   return projectPath
 }
 
@@ -75,6 +76,14 @@ const writeMetadata = async (projectPath, metadata) => {
   }
 }
 
+const mergeMetadata = async (projectPath, kv) => {
+  const { metadata } = await readMetadata(projectPath)
+  if (!metadata) return
+
+  const newMetadata = { ...metadata, ...kv }
+  await writeMetadata(projectPath, newMetadata)
+}
+
 const readPreview = async (projectPath, options = { encoding: 'base64' }) => {
   if (!exists(projectPath)) {
     console.error(`project path does not exist ${projectPath}`)
@@ -106,6 +115,7 @@ export default {
   enumerateProjects,
   readMetadata,
   writeMetadata,
+  mergeMetadata,
   readPreview,
   writePreview
 }


### PR DESCRIPTION
In the project management view projects are now ordered by their last-access time. This time gets updated whenever a user switches to the project.
The last-access time is also set when a user creates a new project. This makes sure that either the recently used or the recently created project is on top of the list.