### PR TITLE
fix/electron builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,6 @@
   "engines": {
     "node": ">=12.0.0"
   },
-  "build": {
-    "appId": "io.syncpoint.odin"
-  },
   "devDependencies": {
     "@babel/core": "^7.8.7",
     "@babel/preset-env": "^7.8.7",

--- a/src/main/bootstrap.js
+++ b/src/main/bootstrap.js
@@ -6,8 +6,6 @@ import projects from '../shared/projects'
 import { exportProject, importProject } from './ipc/share-project'
 import handleCreatePreview from './ipc/create-preview'
 
-import packageJSON from '../../package.json'
-
 /**
  * Facade for application windows/project state.
  * Encapsulates settings access.
@@ -126,8 +124,9 @@ const bootstrap = () => {
   app.on('ready', () => {
     /*
       Setting the appId is required to allow desktop notifications on the Windows platform.
+      Please make sure this value is THE SAME as in 'electron-builder.yml'.
     */
-    app.setAppUserModelId(packageJSON.build.appId)
+    app.setAppUserModelId('io.syncpoint.odin')
 
     /* try to restore persisted window state */
     const state = Object.values(settings.get(WINDOWS_KEY, {}))


### PR DESCRIPTION
An entry in package.json has overwritten the required settings in ```electron-builder.yml```. This PR fixes the problem and electron builds for every platform do run correctly now.