### PR TITLE
fixed invalid application menu for win32

### DIFF
--- a/src/main/menu/application-menu.js
+++ b/src/main/menu/application-menu.js
@@ -2,20 +2,29 @@
 import { app } from 'electron'
 
 const menu = i18n => {
+  if (process.platform === 'darwin') {
+    return {
+      label: app.name,
+      submenu: [
+        { role: 'about', label: i18n.t('app.about', { name: app.name }) },
+        { type: 'separator' },
+        { role: 'services' },
+        { type: 'separator' },
+        { role: 'hide', label: i18n.t('app.hide', { name: app.name }) },
+        { role: 'hideothers', label: i18n.t('app.hideOthers') },
+        { role: 'unhide', label: i18n.t('app.unhide', { name: app.name }) },
+        { type: 'separator' },
+        { role: 'quit', label: i18n.t('app.quit', { name: app.name }) }
+      ]
+    }
+  }
+
   return {
     label: app.name,
     submenu: [
-      { role: 'about', label: i18n.t('app.about', { name: app.name }) },
-      { type: 'separator' },
-      { role: 'services' },
-      { type: 'separator' },
-      { role: 'hide', label: i18n.t('app.hide', { name: app.name }) },
-      { role: 'hideothers', label: i18n.t('app.hideOthers') },
-      { role: 'unhide', label: i18n.t('app.unhide', { name: app.name }) },
-      { type: 'separator' },
       { role: 'quit', label: i18n.t('app.quit', { name: app.name }) }
     ]
   }
 }
 
-export default process.platform === 'darwin' ? menu : null
+export default menu


### PR DESCRIPTION
During the i18n implementation a NULL value for the application menu was returned on the Win32 platform. This PR fixes the problem.