### PR TITLE
fix/zip export in invalid root folder

### DIFF
--- a/src/shared/projects.js
+++ b/src/shared/projects.js
@@ -50,7 +50,7 @@ const exportProject = async (projectPath, targetFilePath) => {
   })
   /* the content of the project folder will be put into the root of the archive */
   odinArchive.pipe(output)
-  odinArchive.directory(projectPath, '.')
+  odinArchive.directory(projectPath, false)
   return odinArchive.finalize().then(() => odinArchive.removeAllListeners())
 }
 


### PR DESCRIPTION
This PR fixes a problem where project files are placed within a folder named  "." inside the zip archive during export.