### PR TITLE
basemap tile provider from preferences (or defaults to OSM)

### DIFF
--- a/src/renderer/map/Map.js
+++ b/src/renderer/map/Map.js
@@ -6,13 +6,13 @@ import * as ol from 'ol'
 import 'ol/ol.css'
 import { fromLonLat, toLonLat } from 'ol/proj'
 import { ScaleLine } from 'ol/control'
-import { Tile as TileLayer } from 'ol/layer'
-import { OSM } from 'ol/source'
+
 
 import evented from '../evented'
 import project from '../project'
 import coordinateFormat from '../../shared/coord-format'
 import layers from './layers'
+import basemap from './basemap'
 import './style/scalebar.css'
 import undo from '../undo'
 
@@ -47,7 +47,6 @@ const effect = props => () => {
 
   const map = new ol.Map({
     view,
-    layers: [new TileLayer({ source: new OSM() })],
     target: id,
     controls: [scaleLine]
   })
@@ -59,6 +58,11 @@ const effect = props => () => {
     // TODO: throttle?
     evented.emit('OSD_MESSAGE', { message: currentCoordinate, slot: 'C2' })
   })
+
+  /*
+    Handling the basemap layer is done using the basemap module.
+  */
+  basemap(map)
 
   // Delegate layer management.
   // Note: We don't directly expose complete Map API,

--- a/src/renderer/map/basemap.js
+++ b/src/renderer/map/basemap.js
@@ -1,0 +1,31 @@
+import project from '../project'
+import { Tile as TileLayer } from 'ol/layer'
+
+/* extends OL's projection definitions */
+import './epsg'
+import { defaultSource, from } from './sources'
+
+
+let olMap = null
+
+const use = source => {
+  /* switch basemap using source */
+}
+
+const handleProjectLifecycle = async action => {
+  if (action !== 'open') return
+
+  const source = project.preferences().basemap
+  const tileSource = await (source ? from(source) : defaultSource())
+
+  olMap.getLayers().insertAt(0, new TileLayer({ source: tileSource }))
+}
+
+project.register(handleProjectLifecycle)
+
+export default map => {
+  olMap = map
+  return {
+    use
+  }
+}

--- a/src/renderer/map/basemap.js
+++ b/src/renderer/map/basemap.js
@@ -5,27 +5,51 @@ import { Tile as TileLayer } from 'ol/layer'
 import './epsg'
 import { defaultSource, from } from './sources'
 
-
+/* set by constructor */
 let olMap = null
 
-const use = source => {
-  /* switch basemap using source */
+const setBasemap = source => {
+
+  const baseLayer = new TileLayer({ source: source })
+  const layers = olMap.getLayers()
+
+  /*
+    We need to verify if the basemap layer is already
+    present and replace or insert it. Our naive approach is
+    to assume that the basemap is an instance of TileLayer
+    (vs VectorLayer). As long as we do not support VectorTileLayer
+    this is sufficient.
+
+    Due to the lifecycle of the map and the project
+    this may be done twice:
+      * at creation time (1)
+      * mount/unmout the map component (2)
+
+    TODO: Verify if this affects performance and we need to
+          add an additional check in order to skip this step
+          if the source has not changed.
+  */
+  const rootLayer = layers.item(0)
+  if (rootLayer && rootLayer instanceof TileLayer) {
+    return olMap.getLayers().setAt(0, baseLayer)
+  }
+  layers.insertAt(0, baseLayer)
 }
 
-const handleProjectLifecycle = async action => {
-  if (action !== 'open') return
-
+const fromPreferences = async () => {
   const source = project.preferences().basemap
   const tileSource = await (source ? from(source) : defaultSource())
+  setBasemap(tileSource)
+}
 
-  olMap.getLayers().insertAt(0, new TileLayer({ source: tileSource }))
+const handleProjectLifecycle = action => {
+  if (action !== 'open') return
+  fromPreferences()
 }
 
 project.register(handleProjectLifecycle)
 
 export default map => {
   olMap = map
-  return {
-    use
-  }
+  fromPreferences()
 }

--- a/src/renderer/map/basemap.js
+++ b/src/renderer/map/basemap.js
@@ -11,7 +11,6 @@ let olMap = null
 const setBasemap = source => {
 
   const baseLayer = new TileLayer({ source: source })
-  const layers = olMap.getLayers()
 
   /*
     We need to verify if the basemap layer is already
@@ -22,13 +21,20 @@ const setBasemap = source => {
 
     Due to the lifecycle of the map and the project
     this may be done twice:
-      * at creation time (1)
-      * mount/unmout the map component (2)
+
+    When the map react component gets mounted for the first
+    time the constructor is called AND the project fires the
+    'OPEN' event.
+    We need to call 'fromPreferences()' in the constructor AND
+    on the project's 'open' event because when the map component
+    gets unmounted/remounted, the project stays open and will
+    not fire again.
 
     TODO: Verify if this affects performance and we need to
           add an additional check in order to skip this step
           if the source has not changed.
   */
+  const layers = olMap.getLayers()
   const rootLayer = layers.item(0)
   if (rootLayer && rootLayer instanceof TileLayer) {
     return olMap.getLayers().setAt(0, baseLayer)

--- a/src/renderer/map/epsg/epsg.json
+++ b/src/renderer/map/epsg/epsg.json
@@ -1,0 +1,17 @@
+[
+  {
+    "name": "MGI / Austria GK M31",
+    "code": "EPSG:31258", 
+    "definition": "+proj=tmerc +lat_0=0 +lon_0=13.33333333333333 +k=1 +x_0=450000 +y_0=-5000000 +ellps=bessel +towgs84=577.326,90.129,463.919,5.137,1.474,5.297,2.4232 +units=m +no_defs"
+  },
+  {
+    "name": "MGI / Austria GK M34",
+    "code": "EPSG:31259", 
+    "definition": "+proj=tmerc +lat_0=0 +lon_0=16.33333333333333 +k=1 +x_0=750000 +y_0=-5000000 +ellps=bessel +towgs84=577.326,90.129,463.919,5.137,1.474,5.297,2.4232 +units=m +no_defs"
+  },
+  {
+    "name": "CH1903 / LV03 -- Swiss CH1903 / LV03",
+    "code": "EPSG:21781", 
+    "definition": "+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=600000 +y_0=200000 +ellps=bessel +towgs84=674.4,15.1,405.3,0,0,0,0 +units=m +no_defs"
+  }
+]

--- a/src/renderer/map/epsg/index.js
+++ b/src/renderer/map/epsg/index.js
@@ -1,0 +1,10 @@
+import proj4 from 'proj4'
+import { register } from 'ol/proj/proj4'
+import projections from './epsg.json'
+
+projections.forEach(projection => {
+  proj4.defs(projection.code, projection.definition)
+})
+
+/* make projections available to OL */
+register(proj4)

--- a/src/renderer/map/sources/index.js
+++ b/src/renderer/map/sources/index.js
@@ -1,0 +1,67 @@
+import OSM from 'ol/source/OSM'
+import XYZ from 'ol/source/XYZ'
+import WMTS, { optionsFromCapabilities } from 'ol/source/WMTS'
+import WMTSCapabilities from 'ol/format/WMTSCapabilities'
+import { DEVICE_PIXEL_RATIO } from 'ol/has'
+
+import { app, remote } from 'electron'
+import fs from 'fs'
+import path from 'path'
+
+const HOME = remote ? remote.app.getPath('home') : app.getPath('home')
+const ODIN_HOME = path.join(HOME, 'ODIN')
+const ODIN_SOURCES = path.join(ODIN_HOME, 'sources.json')
+
+const DEFAULT_SOURCE = {
+  name: 'Open Street Map',
+  type: 'OSM'
+}
+
+const highDPI = DEVICE_PIXEL_RATIO > 1
+const defaultSource = () => from(DEFAULT_SOURCE)
+
+const listSources = async () => {
+  if (!fs.existsSync(ODIN_SOURCES)) return [DEFAULT_SOURCE]
+
+  const sources = await fs.promises.readFile(ODIN_SOURCES, 'utf-8')
+  return JSON.parse(sources)
+}
+
+const fromWMTS = async (source) => {
+  try {
+    const response = await fetch(source.url)
+    const capabilities = (new WMTSCapabilities()).read(await response.text())
+    const wmtsOptions = optionsFromCapabilities(capabilities, source.options)
+    wmtsOptions.tilePixelRatio = (highDPI ? 2 : 1)
+    return new WMTS(wmtsOptions)
+  } catch (error) {
+    console.error(error)
+  }
+}
+
+const from = async (source) => {
+  switch (source.type) {
+    case 'OSM': {
+      return new OSM(source.options)
+    }
+    case 'WMTS': {
+      const wmtsSource = await fromWMTS(source)
+      return wmtsSource
+    }
+    case 'XYZ': {
+      return new XYZ(source.options)
+    }
+    default: {
+      console.error(`unknown source type: ${source.type}`)
+      return defaultSource()
+    }
+  }
+}
+
+
+
+export {
+  defaultSource,
+  listSources,
+  from
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,16 +34,6 @@ const RULES = {
   font: {
     test: /\.(eot|svg|ttf|woff|woff2)$/,
     use: [{ loader: `file-loader?name=font/[name]__[${hash}].[ext]` }]
-  },
-
-  json: {
-    test: /\.(json)$/,
-    use: [{
-      loader: 'file-loader',
-      options: {
-        name: `data/[name]__[${hash}].[ext]`
-      }
-    }]
   }
 }
 


### PR DESCRIPTION
This PR allows reading the basemap tile provider settings from the project preferences. It also sets the foundation for basemap management done by the user.

If the there are no preferences the basemap provider will add an OSM TileLayer. It supports OSM, XYZ and WMTS tile sources. In order to test the functionality one can add Austria's ```basemap.at``` to the projects ```preferences.json``` file:

```json
"basemap": {
    "type": "WMTS",
    "url": "https://www.basemap.at/wmts/1.0.0/WMTSCapabilities.xml",
    "name": "basemap.at HighDPI",
    "options": {
      "layer": "bmaphidpi",
      "matrixSet": "google3857",
      "style": "normal"
    }
  }
```

Since WMTS may provide tiles with a non-Web-Mercator projection it was also required to start adding additional projection definitions. Currently there are 3 definitions included (should be extended!): Austria's Lambert Projection (2) and Swiss Topo (1). 
