### PR TITLE
Replaced electron mocha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9369,9 +9369,9 @@
           }
         },
         "glob-parent": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
-          "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
           "dev": true,
           "requires": {
             "is-glob": "^4.0.1"
@@ -10566,9 +10566,9 @@
       "dev": true
     },
     "picomatch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
-      "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
       "dev": true
     },
     "pify": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2325,6 +2325,12 @@
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
     },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -3236,6 +3242,20 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
+    "chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
+      }
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -3251,6 +3271,12 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
     "cheerio": {
@@ -4068,6 +4094,15 @@
       "dev": true,
       "requires": {
         "mimic-response": "^1.0.0"
+      }
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
       }
     },
     "deep-equal": {
@@ -7082,6 +7117,12 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
     "get-stdin": {
@@ -10530,6 +10571,12 @@
           "dev": true
         }
       }
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
     },
     "pbf": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "builder:linux": "electron-builder --linux",
     "eslint": "eslint src/",
     "test": "electron-mocha --require @babel/register --require ./test/helpers.js --require ./test/dom.js --require ignore-styles --recursive",
-    "spectron": "electron-mocha --require @babel/register --recursive spectron"
+    "spectron": "mocha --require @babel/register --recursive spectron"
   },
   "repository": {
     "type": "git",
@@ -57,6 +57,7 @@
     "html-webpack-plugin": "^3.2.0",
     "ignore-styles": "^5.0.1",
     "jsdom": "^16.2.2",
+    "mocha": "^7.1.1",
     "sinon": "^9.0.1",
     "spectron": "^10.0.1",
     "style-loader": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@babel/register": "^7.9.0",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.1.0",
+    "chai": "^4.2.0",
     "css-loader": "^3.4.2",
     "electron": "^8.2.0",
     "electron-builder": "^22.4.1",

--- a/spectron/hooks.js
+++ b/spectron/hooks.js
@@ -9,8 +9,7 @@ module.exports = {
       path: electron,
       args: [path.join(__dirname, '..'), '--noDevServer']
     }).start()
-    //await app.browserWindow.focus();
-    await app.browserWindow.setAlwaysOnTop(true);
+    await app.browserWindow.setAlwaysOnTop(true)
     return app
   },
 

--- a/spectron/hooks.js
+++ b/spectron/hooks.js
@@ -1,13 +1,16 @@
 import { Application } from 'spectron'
+import electron from 'electron'
 import path from 'path'
 
 module.exports = {
   async startApp () {
     const app = await new Application({
       startTimeout: 30000,
-      path: path.resolve(__dirname, '../node_modules/.bin/electron'),
+      path: electron,
       args: [path.join(__dirname, '..'), '--noDevServer']
     }).start()
+    //await app.browserWindow.focus();
+    await app.browserWindow.setAlwaysOnTop(true);
     return app
   },
 

--- a/spectron/projectManagement.test.js
+++ b/spectron/projectManagement.test.js
@@ -1,7 +1,6 @@
 import hooks from './hooks'
 import { clickElementById } from './UiHelper'
 import assert from 'assert'
-import projects from '../src/shared/projects'
 import path from 'path'
 
 describe('menu test', function () {
@@ -55,11 +54,5 @@ describe('menu test', function () {
     await clickElementById(app, '#backToMap')
   })
 
-  it('imports the test project and switches to it', async function () {
-    app.browserWindow.send('IPC_SHOW_PROJECT_MANAGEMENT')
-    const projectPath = path.join(__dirname, '/test_projects/EmptyProject.odin')
-    await projects.importProject(projectPath)
-    await clickElementById(app, '#switchTo' + emptyTestProject)
-  })
-
 })
+

--- a/test/renderer/components/management.test.js
+++ b/test/renderer/components/management.test.js
@@ -1,7 +1,8 @@
 import Management from '../../../src/renderer/components/Management'
 import React from 'react'
-import assert from 'assert'
 import sinon from 'sinon'
+import { expect } from 'chai'
+
 
 /* eslint-disable no-undef */
 describe('Management', () => {
@@ -9,13 +10,11 @@ describe('Management', () => {
   const wrapper = shallow(<Management currentProjectPath={''} onCloseClicked={clickCallback} />)
 
   it('verify project management components', () => {
-    assert(wrapper.find('projects'), true, 'no projects area')
-    assert(wrapper.find('projectList'), true, 'no project list')
-    assert(wrapper.find('projectActions'), true, 'no project actions')
-    assert(wrapper.find('details'), true, 'no project details')
-    assert(wrapper.find('preview'), true, 'no project preview')
-    assert(wrapper.find('projectSettings'), true, 'no projectSettings')
-    assert(wrapper.find('dangerousActions'), true, 'no project dangerousActions')
+    expect(wrapper.find('#projects')).to.have.lengthOf(1)
+    expect(wrapper.find('#importProject')).to.have.lengthOf(1)
+    expect(wrapper.find('#projectList')).to.have.lengthOf(1)
+    expect(wrapper.find('#projectActions')).to.have.lengthOf(1)
+    expect(wrapper.find('Details'), 'details').to.have.lengthOf(1)
   })
 
   it('verify back to map button is clicked', () => {


### PR DESCRIPTION
Using mocha for spectron instead of electron-mocha. On Windows there are multiple empty terminals popping up on spectron startup due to issue #60. So setAlwaysOnTop is required as a workaround.
