### PR TITLE
configure language settings with environment variable

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -26,4 +26,6 @@ jobs:
         uses: GabrielBB/xvfb-action@v1.0
         with:
           run: npm test
+        env:
+          ODIN_LANGUAGE: cimode
     

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ tile-providers.json
 dist/
 binaries/
 .idea/
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -4435,8 +4435,7 @@
     "dotenv": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
-      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
-      "dev": true
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
     },
     "dotenv-expand": {
       "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@material-ui/core": "^4.9.8",
     "@material-ui/icons": "^4.9.1",
     "archiver": "^3.1.1",
+    "dotenv": "^8.2.0",
     "electron-settings": "^3.2.0",
     "geodesy": "^2.2.0",
     "geographiclib": "^1.50.0",

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -5,6 +5,7 @@ import { buildFromTemplate } from '../main/menu/menu'
 import settings from 'electron-settings'
 import bootstrap from './bootstrap'
 import i18n, { languageKey } from '../i18n'
+import config from '../shared/config'
 
 // Disable for production:
 process.env['ELECTRON_DISABLE_SECURITY_WARNINGS'] = 'true'
@@ -21,6 +22,7 @@ app.allowRendererProcessReuse = false // `false` also removes deprecation messag
     In order to add/remove recently used projects we need to rebuild and
     set the application menu.
 */
+
 const buildApplicationMenu = () => {
   const menu = buildFromTemplate(i18n)
   Menu.setApplicationMenu(menu)
@@ -32,6 +34,11 @@ i18n.on('languageChanged', lng => {
 })
 
 i18n.on('initialized', () => {
-  i18n.changeLanguage(settings.get(languageKey, 'en'))
+  /*
+    By using an environment variable or a ".env" file users may change the language used.
+    The ".env" file must be placed in the working directory and is NOT part of the
+    software distribution.
+  */
+  i18n.changeLanguage(config.language || settings.get(languageKey, 'en'))
   bootstrap()
 })

--- a/src/shared/config.js
+++ b/src/shared/config.js
@@ -1,0 +1,15 @@
+import dotenv from 'dotenv'
+
+/*
+  Quote from the 'dotenv' documentation:
+  "config will read your .env file, parse the contents, assign it to process.env,
+  and return an Object with a parsed key containing the loaded content or an error
+  key if it failed."
+*/
+dotenv.config()
+
+const config = {
+  language: process.env.ODIN_LANGUAGE
+}
+
+export default config


### PR DESCRIPTION
By using the environment variable ```ODIN_LANGUAGE``` the ui language of ODIN can be set. The variable can also be set by creating a file named ```.env``` in the working directory.
All key-value pairs in the file are added to the ```process.env```. 

In order to create language-independent end-to-end tests the i18n framework used supports the language code ```cimode```. In this mode the frameworks returns the i18n key instead of the translation.