### PR TITLE
Babel now transpiles node_modules when running npm test.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "builder:win": "electron-builder --win",
     "builder:linux": "electron-builder --linux",
     "eslint": "eslint src/",
-    "test": "electron-mocha --require @babel/register --require ./test/helpers.js --require ./test/dom.js --require ignore-styles --recursive",
+    "test": "electron-mocha --require ./test/register.js --require ./test/helpers.js --require ./test/dom.js --require ignore-styles --recursive",
     "spectron": "mocha --require @babel/register --recursive spectron"
   },
   "repository": {

--- a/test/import-test.js
+++ b/test/import-test.js
@@ -1,7 +1,8 @@
 import assert from 'assert'
+import ol from 'ol'
 
 describe('mocha', function () {
-  it('understands ES6 import statement', function () {
+  it('understands ES6 import statement from internal and external modules', function () {
     assert(assert)
   })
 })

--- a/test/register.js
+++ b/test/register.js
@@ -1,0 +1,4 @@
+require("@babel/register")({
+    ignore: [],
+    "presets": ["@babel/preset-env", "@babel/preset-react"]
+})


### PR DESCRIPTION
By default babel ignores node_modules. If a test or a tested file imports a module which must be transpiled this will lead to test failures.