### PR TITLE
basemap/opacity

### DIFF
--- a/src/i18n/de/web.json
+++ b/src/i18n/de/web.json
@@ -54,5 +54,8 @@
     "delete": "Layer löschen",
     "duplicate": "Layer duplizieren",
     "share": "Layer teilen"
+  },
+  "basemaps": {
+    "opacity": "Deckkraft"
   }
 }

--- a/src/i18n/en/web.json
+++ b/src/i18n/en/web.json
@@ -54,5 +54,8 @@
     "delete": "Delete Layer",
     "duplicate": "Duplicate Layer",
     "share": "Share Layer"
+  },
+  "basemaps": {
+    "opacity": "Opacity"
   }
 }

--- a/src/renderer/components/basemapPanel/BasemapList.js
+++ b/src/renderer/components/basemapPanel/BasemapList.js
@@ -6,7 +6,7 @@ import ItemTypes from './DnDItemTypes'
 import BasemapListItem from './BasemapListItem'
 import Opacity from './Opacity'
 
-import { register, deregister, toggleVisibility, setZIndices } from '../../map/basemap/group'
+import { register, deregister, toggleVisibility, setZIndices, setOpacity } from '../../map/basemap/group'
 
 import { Paper } from '@material-ui/core'
 
@@ -45,6 +45,7 @@ const BasemapList = props => {
   const classes = useStyles()
 
   const [basemapLayers, setBasemapLayers] = React.useState([])
+  const [selectedBasemap, setSelectedBasemap] = React.useState(null)
 
   React.useEffect(() => {
     const handleBasemapLayersChanged = ({ type, value }) => {
@@ -84,6 +85,20 @@ const BasemapList = props => {
     if (id) toggleVisibility(id)
   }
 
+  const handleTuneClicked = id => {
+    if (isSelected(id)) {
+      setSelectedBasemap(null)
+    } else {
+      setSelectedBasemap(basemapLayers.find(layer => layer.id === id))
+    }
+  }
+
+  const handleOpacityChanged = (event, value) => {
+    if (!selectedBasemap) return
+    setOpacity(selectedBasemap.id, value)
+  }
+
+  const isSelected = id => selectedBasemap && selectedBasemap.id === id
   const cssClass = isOver ? classes.itemListActive : classes.itemList
 
   return (
@@ -99,20 +114,23 @@ const BasemapList = props => {
                 id={layer.id}
                 text={layer.name}
                 visible={layer.visible}
+                selected={isSelected(layer.id)}
                 moveBasemapItem={moveBasemapItem}
                 visibilityClicked={handleVisibilityClicked}
+                tuneClicked={handleTuneClicked}
                 onDrop={handleItemDropped}
               />
             )).reverse()
           }
         </ul>
-        <ul className={classes.controls}>
-          <Opacity />
-        </ul>
+        { selectedBasemap
+          ? <ul className={classes.controls}>
+            <Opacity key={selectedBasemap.id} onChange={handleOpacityChanged} defaultValue={selectedBasemap.opacity}/>
+          </ul>
+          : null
+        }
       </div>
-
     </Paper>
-
   )
 }
 

--- a/src/renderer/components/basemapPanel/BasemapList.js
+++ b/src/renderer/components/basemapPanel/BasemapList.js
@@ -4,6 +4,7 @@ import { useDrop } from 'react-dnd'
 import ItemTypes from './DnDItemTypes'
 
 import BasemapListItem from './BasemapListItem'
+import Opacity from './Opacity'
 
 import { register, deregister, toggleVisibility, setZIndices } from '../../map/basemap/group'
 
@@ -14,7 +15,8 @@ const useStyles = makeStyles(theme => ({
     gridArea: 'L',
     pointerEvents: 'auto',
     display: 'flex',
-    flexDirection: 'column'
+    flexDirection: 'column',
+    position: 'relative'
   },
   listContainer: {
     height: '100%',
@@ -25,6 +27,16 @@ const useStyles = makeStyles(theme => ({
   },
   itemListActive: {
     listStyleType: 'none', padding: '4px', backgroundColor: theme.palette.action.hover
+  },
+  controls: {
+    position: 'absolute',
+    bottom: 0,
+    width: '90%',
+    paddingInlineStart: '0px',
+    margin: theme.spacing(1.5)
+  },
+  control: {
+    listStyleType: 'none', padding: '4px', margin: '4px', paddingInlineStart: 0
   }
 }))
 
@@ -94,7 +106,11 @@ const BasemapList = props => {
             )).reverse()
           }
         </ul>
+        <ul className={classes.controls}>
+          <Opacity />
+        </ul>
       </div>
+
     </Paper>
 
   )

--- a/src/renderer/components/basemapPanel/BasemapListItem.js
+++ b/src/renderer/components/basemapPanel/BasemapListItem.js
@@ -5,7 +5,6 @@ import ItemTypes from './DnDItemTypes'
 
 import VisibilityIcon from '@material-ui/icons/Visibility'
 import VisibilityOffIcon from '@material-ui/icons/VisibilityOff'
-import TuneIcon from '@material-ui/icons/Tune'
 import DragHandle from '@material-ui/icons/DragHandle'
 
 import { makeStyles } from '@material-ui/core/styles'
@@ -14,12 +13,17 @@ import { ListItem, ListItemSecondaryAction, Typography, IconButton } from '@mate
 const useStyle = makeStyles(theme => ({
   listItem: {
     margin: theme.spacing(0.25),
-    border: '1px solid #cccccc',
+    border: `1px solid ${theme.palette.grey['400']}`,
     borderRadius: '2px',
     padding: theme.spacing(1)
   },
-  actions: {
-    float: 'right'
+  clickable: {
+    cursor: 'pointer',
+    width: '75%',
+    '&:hover': {
+      backgroundColor: theme.palette.action.hover
+    },
+    padding: theme.spacing(0.5)
   }
 }))
 
@@ -94,14 +98,15 @@ const BasemapListItem = (props) => {
   drag(drop(ref))
 
   return (
-    <ListItem ref={ref} className={classes.listItem} style={{ opacity }} selected={props.selected}>
-      <DragHandle color={visible ? 'inherit' : 'disabled'}/>
-      <Typography variant="button" color={visible ? 'initial' : 'textSecondary'}>{text}</Typography>
+    <ListItem ref={ref} className={classes.listItem} style={{ opacity }} selected={props.selected}
+      onClick={() => tuneClicked(id)}
+    >
+      <DragHandle color={visible ? 'inherit' : 'disabled'} style={{ cursor: 'grab' }}/>
+      <div className={classes.clickable}>
+        <Typography variant="button" color={visible ? 'initial' : 'textSecondary'}>{text}</Typography>
+      </div>
       { opacity === 1
         ? <ListItemSecondaryAction >
-          <IconButton onClick={() => tuneClicked(id)}>
-            <TuneIcon size="small" />
-          </IconButton>
           <IconButton size="small" onClick={() => visibilityClicked(id)}>
             { visible ? <VisibilityIcon /> : <VisibilityOffIcon /> }
           </IconButton>

--- a/src/renderer/components/basemapPanel/BasemapListItem.js
+++ b/src/renderer/components/basemapPanel/BasemapListItem.js
@@ -5,6 +5,7 @@ import ItemTypes from './DnDItemTypes'
 
 import VisibilityIcon from '@material-ui/icons/Visibility'
 import VisibilityOffIcon from '@material-ui/icons/VisibilityOff'
+import TuneIcon from '@material-ui/icons/Tune'
 import DragHandle from '@material-ui/icons/DragHandle'
 
 import { makeStyles } from '@material-ui/core/styles'
@@ -26,7 +27,7 @@ const useStyle = makeStyles(theme => ({
 const BasemapListItem = (props) => {
 
   const { id, text, index, visible } = props
-  const { moveBasemapItem, visibilityClicked, onDrop } = props
+  const { moveBasemapItem, visibilityClicked, tuneClicked, onDrop } = props
 
   const classes = useStyle()
   const ref = React.useRef(null)
@@ -93,11 +94,14 @@ const BasemapListItem = (props) => {
   drag(drop(ref))
 
   return (
-    <ListItem ref={ref} className={classes.listItem} style={{ opacity }}>
+    <ListItem ref={ref} className={classes.listItem} style={{ opacity }} selected={props.selected}>
       <DragHandle color={visible ? 'inherit' : 'disabled'}/>
       <Typography variant="button" color={visible ? 'initial' : 'textSecondary'}>{text}</Typography>
       { opacity === 1
         ? <ListItemSecondaryAction >
+          <IconButton onClick={() => tuneClicked(id)}>
+            <TuneIcon size="small" />
+          </IconButton>
           <IconButton size="small" onClick={() => visibilityClicked(id)}>
             { visible ? <VisibilityIcon /> : <VisibilityOffIcon /> }
           </IconButton>
@@ -113,8 +117,10 @@ BasemapListItem.propTypes = {
   text: PropTypes.string,
   index: PropTypes.number,
   visible: PropTypes.bool,
+  selected: PropTypes.bool,
   moveBasemapItem: PropTypes.func,
   visibilityClicked: PropTypes.func,
+  tuneClicked: PropTypes.func,
   onDrop: PropTypes.func
 }
 

--- a/src/renderer/components/basemapPanel/Opacity.js
+++ b/src/renderer/components/basemapPanel/Opacity.js
@@ -1,0 +1,35 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Typography, Slider } from '@material-ui/core'
+
+const Opacity = props => {
+  const marks = [
+    { label: '0%', value: 0 },
+    { label: '100%', value: 1 }
+  ]
+
+  return (
+    <>
+      <Typography id="non-linear-slider">
+      Basemap Opacity
+      </Typography>
+      <Slider
+        marks={marks}
+        min={0}
+        max={1}
+        scale={v => v * 100}
+        step={0.01}
+        value={props.value}
+        aria-labelledby="non-linear-slider"
+        onChange={props.onChange}
+      />
+    </>
+  )
+}
+
+Opacity.propTypes = {
+  value: PropTypes.number.isRequired,
+  onChange: PropTypes.func.isRequired
+}
+
+export default Opacity

--- a/src/renderer/components/basemapPanel/Opacity.js
+++ b/src/renderer/components/basemapPanel/Opacity.js
@@ -2,7 +2,11 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Typography, Slider } from '@material-ui/core'
 
+import { useTranslation } from 'react-i18next'
+
 const Opacity = props => {
+  const { t } = useTranslation()
+
   const marks = [
     { label: '0%', value: 0 },
     { label: '100%', value: 1 }
@@ -10,8 +14,8 @@ const Opacity = props => {
 
   return (
     <>
-      <Typography id="non-linear-slider">
-      Basemap Opacity
+      <Typography id="linear-slider">
+        {t('basemaps.opacity')}
       </Typography>
       <Slider
         marks={marks}
@@ -19,8 +23,8 @@ const Opacity = props => {
         max={1}
         scale={v => v * 100}
         step={0.01}
-        value={props.value}
-        aria-labelledby="non-linear-slider"
+        defaultValue={props.defaultValue}
+        aria-labelledby="linear-slider"
         onChange={props.onChange}
       />
     </>
@@ -28,7 +32,7 @@ const Opacity = props => {
 }
 
 Opacity.propTypes = {
-  value: PropTypes.number.isRequired,
+  defaultValue: PropTypes.number.isRequired,
   onChange: PropTypes.func.isRequired
 }
 

--- a/src/renderer/map/basemap/group.js
+++ b/src/renderer/map/basemap/group.js
@@ -118,6 +118,14 @@ export const toggleVisibility = (layerId, onSuccess = ACTIONS.persistAndEmit) =>
   setVisibility(layerId, !layer.getVisible(), onSuccess)
 }
 
+export const setOpacity = (layerId, opacity, onSuccess = ACTIONS.persistAndEmit) => {
+  if (!layerId || opacity === undefined) return
+  const layer = layerById(layerId)
+  if (!layer) return
+  layer.setOpacity(opacity)
+  onSuccess()
+}
+
 /**
  *
  * @param {*} layerIds array of layer ids that define the order of the tile layers
@@ -162,7 +170,10 @@ const init = async sourceDescriptors => {
   const basemaps = preferences.get('basemaps') || []
   if (basemaps.length > 0) {
     setZIndices(basemaps.map(basemap => basemap.id), ACTIONS.noop)
-    basemaps.forEach(basemap => setVisibility(basemap.id, basemap.visible, ACTIONS.noop))
+    basemaps.forEach(basemap => {
+      setVisibility(basemap.id, basemap.visible, ACTIONS.noop)
+      setOpacity(basemap.id, basemap.opacity, ACTIONS.noop)
+    })
     ACTIONS.emit()
   } else {
     /*


### PR DESCRIPTION
PR introduces the ability to change the opacity of basemaps. This allows users to create an even better appearance of the resulting basemap by stacking them and change the opacity individually.

<img width="967" alt="image" src="https://user-images.githubusercontent.com/38359572/82757499-227c5f00-9de1-11ea-81b0-c584fbf4780f.png">
