### PR TITLE
fixed invalid width of the scalebar

### DIFF
--- a/src/renderer/map/style/scalebar.css
+++ b/src/renderer/map/style/scalebar.css
@@ -5,5 +5,7 @@
 }
 .ol-scale-bar-inner div:nth-child(6) div{
     background-color: red !important;
-
+}
+.ol-scale-singlebar {
+  box-sizing: border-box;
 }


### PR DESCRIPTION
PR fixes the width of the OL/ScaleBar and makes it align correctly with the MGRS grid. See here for a potential upstream fix: https://github.com/openlayers/openlayers/issues/11118