### PR TITLE
export current view to png

### DIFF
--- a/src/i18n/de/electron.json
+++ b/src/i18n/de/electron.json
@@ -44,10 +44,10 @@
     "close": "Schließen",
     "zoom": "Zoomen"
   },
-  "exportProject": {
-    "title": "Export des Projekts {{name}}",
-    "succeeded": "Export des Projekts {{name}} war erfolgreich",
-    "failed": "Export des Projekts {{name}} ist fehlgeschlagen",
+  "export": {
+    "title": "Export {{name}}",
+    "succeeded": "Export war erfolgreich: {{name}}",
+    "failed": "Export ist fehlgeschlagen: {{name}}",
     "clickToOpen": "Öffnen: {{path}}"
   },
   "importProject": {

--- a/src/i18n/de/web.json
+++ b/src/i18n/de/web.json
@@ -46,7 +46,8 @@
       "redo": "Wiederherstellen",
       "cut": "Ausschneiden",
       "copy": "Kopieren",
-      "paste": "Einfügen"
+      "paste": "Einfügen",
+      "share": "Teilen (PNG)"
     }
   },
   "layers": {

--- a/src/i18n/en/electron.json
+++ b/src/i18n/en/electron.json
@@ -44,10 +44,10 @@
     "close": "Close",
     "zoom": "Zoom"
   },
-  "exportProject": {
-    "title": "Export project {{name}}",
-    "succeeded": "Export of project {{name}} succeeded",
-    "failed": "Export of project {{name}} failed",
+  "export": {
+    "title": "Export {{name}}",
+    "succeeded": "Export succeeded: {{name}}",
+    "failed": "Export failed: {{name}}",
     "clickToOpen": "Open: {{path}}"
   },
   "importProject": {

--- a/src/i18n/en/web.json
+++ b/src/i18n/en/web.json
@@ -46,7 +46,8 @@
       "redo": "Redo",
       "cut": "Cut",
       "copy": "Copy",
-      "paste": "Paste"
+      "paste": "Paste",
+      "share": "Share (PNG)"
     }
   },
   "layers": {

--- a/src/main/bootstrap.js
+++ b/src/main/bootstrap.js
@@ -4,6 +4,7 @@ import { app, BrowserWindow, ipcMain, dialog } from 'electron'
 import settings from 'electron-settings'
 import projects from '../shared/projects'
 import { exportProject, importProject } from './ipc/share-project'
+import { viewAsPng } from './ipc/share-view'
 import handleCreatePreview from './ipc/create-preview'
 import i18n from '../i18n'
 import './ipc/source-descriptors'
@@ -192,6 +193,9 @@ const bootstrap = () => {
   /* emitted by renderer/components/Management.js */
   ipcMain.on('IPC_EXPORT_PROJECT', exportProject)
   ipcMain.on('IPC_IMPORT_PROJECT', importProject)
+
+  /* share view */
+  ipcMain.on('IPC_SHARE_PNG', viewAsPng)
 
   /* emitted by renderer/App */
   ipcMain.on('IPC_APP_RENDERING_COMPLETED', event => {

--- a/src/main/ipc/share-project.js
+++ b/src/main/ipc/share-project.js
@@ -17,8 +17,8 @@ export const exportProject = async (event, projectPath) => {
       await projects.exportProject(projectPath, result.filePath)
       if (!Notification.isSupported()) return
       const n = new Notification({
-        title: i18n.t('exportProject.succeeded', { name: project.metadata.name }),
-        body: i18n.t('exportProject.clickToOpen', { path: result.filePath })
+        title: i18n.t('export.succeeded', { name: project.metadata.name }),
+        body: i18n.t('export.clickToOpen', { path: result.filePath })
       })
       n.on('click', () => {
         shell.showItemInFolder(result.filePath)
@@ -26,7 +26,7 @@ export const exportProject = async (event, projectPath) => {
       n.show()
     } catch (error) {
       const n = new Notification({
-        title: i18n.t('exportProject.failed', { name: project.metadata.title }),
+        title: i18n.t('export.failed', { name: project.metadata.title }),
         body: error.message
       })
       n.show()

--- a/src/main/ipc/share-view.js
+++ b/src/main/ipc/share-view.js
@@ -1,0 +1,39 @@
+import { dialog, Notification, shell } from 'electron'
+import sanitizeFilename from 'sanitize-filename'
+import fs from 'fs'
+import projects from '../../shared/projects'
+import i18n from '../../i18n'
+
+export const viewAsPng = async (event, pngImageData) => {
+  const sender = event.sender.getOwnerBrowserWindow()
+  if (!sender.path) return
+  const project = await projects.readMetadata(sender.path)
+  const filenameSuggestion = sanitizeFilename(project.metadata.name)
+  const dialogOptions = {
+    defaultPath: filenameSuggestion,
+    filters: [
+      { name: 'png', extensions: ['png'] }
+    ]
+  }
+  /* providing getOwnerBrowserWindow creates a modal dialog */
+  dialog.showSaveDialog(event.sender.getOwnerBrowserWindow(), dialogOptions).then(async result => {
+    if (result.canceled) return
+    try {
+      await fs.promises.writeFile(result.filePath, pngImageData, { encoding: 'base64' })
+      const n = new Notification({
+        title: i18n.t('export.succeeded', { name: project.metadata.name }),
+        body: i18n.t('export.clickToOpen', { path: result.filePath })
+      })
+      n.on('click', () => {
+        shell.showItemInFolder(result.filePath)
+      })
+      n.show()
+    } catch (error) {
+      const n = new Notification({
+        title: i18n.t('export.failed', { name: project.metadata.title }),
+        body: error.message
+      })
+      n.show()
+    }
+  })
+}

--- a/src/renderer/components/Activities.js
+++ b/src/renderer/components/Activities.js
@@ -4,6 +4,7 @@ import Paper from '@material-ui/core/Paper'
 import Category from '@material-ui/icons/Category'
 import PermDataSettingIcon from '@material-ui/icons/PermDataSetting'
 import MapIcon from '@material-ui/icons/Map'
+import ShareIcon from '@material-ui/icons/Share'
 import { LayersTriple, Undo, Redo, ContentCut, ContentCopy, ContentPaste } from 'mdi-material-ui'
 
 import ActivityBar from './ActivityBar'
@@ -93,6 +94,16 @@ const initialActivities = (classes, t) => [
     icon: <ContentPaste/>,
     tooltip: t('activities.tooltips.paste'),
     action: () => evented.emit('EDIT_PASTE')
+  },
+  {
+    type: 'divider'
+  },
+  {
+    id: 'sharePng',
+    type: 'action',
+    icon: <ShareIcon/>,
+    tooltip: t('activities.tooltips.share'),
+    action: () => evented.emit('SHARE_PNG')
   }
 ]
 

--- a/src/renderer/map/Map.js
+++ b/src/renderer/map/Map.js
@@ -15,6 +15,7 @@ import preferences from '../project/preferences'
 import coordinateFormat from '../../shared/coord-format'
 import layers from './layers'
 import draw from './draw'
+import share from './share'
 import './style/scalebar.css'
 
 const zoom = view => view.getZoom()
@@ -67,6 +68,7 @@ const effect = props => () => {
 
   layers(map)
   draw(map)
+  share(map)
 
   // Set viewport and basemap from preferences.
   preferences.register(({ type, preferences }) => {

--- a/src/renderer/map/basemap/tileSources.js
+++ b/src/renderer/map/basemap/tileSources.js
@@ -28,6 +28,7 @@ const sources = {
     const capabilities = (new WMTSCapabilities()).read(await response.text())
     const wmtsOptions = optionsFromCapabilities(capabilities, descriptor.options)
     wmtsOptions.tilePixelRatio = (highDPI ? 2 : 1)
+    wmtsOptions.crossOrigin = 'anonymous'
     return new WMTS(wmtsOptions)
   }
 }

--- a/src/renderer/map/share.js
+++ b/src/renderer/map/share.js
@@ -15,7 +15,7 @@ const pngExport = async map => {
       mapContext.globalAlpha = opacity === '' ? 1 : Number(opacity)
       const transform = canvas.style.transform
       // Get the transform parameters from the style's transform matrix
-      const matrix = transform.match(/^matrix\(([^\(]*)\)$/)[1].split(',').map(Number)
+      const matrix = transform.match(/^matrix\(([^(]*)\)$/)[1].split(',').map(Number)
       // Apply the transform to the export map context
       CanvasRenderingContext2D.prototype.setTransform.apply(mapContext, matrix)
       mapContext.drawImage(canvas, 0, 0)

--- a/src/renderer/map/share.js
+++ b/src/renderer/map/share.js
@@ -1,0 +1,32 @@
+import evented from '../evented'
+import { ipcRenderer } from 'electron'
+
+const pngExport = async map => {
+  // this is a web application, so there is a global object "document"
+  const mapCanvas = document.createElement('canvas')
+  const [width, heigth] = map.getSize()
+  mapCanvas.width = width
+  mapCanvas.height = heigth
+
+  const mapContext = mapCanvas.getContext('2d')
+  document.querySelectorAll('.ol-layer canvas').forEach(canvas => {
+    if (canvas.width > 0) {
+      const opacity = canvas.parentNode.style.opacity
+      mapContext.globalAlpha = opacity === '' ? 1 : Number(opacity)
+      const transform = canvas.style.transform
+      // Get the transform parameters from the style's transform matrix
+      const matrix = transform.match(/^matrix\(([^\(]*)\)$/)[1].split(',').map(Number)
+      // Apply the transform to the export map context
+      CanvasRenderingContext2D.prototype.setTransform.apply(mapContext, matrix)
+      mapContext.drawImage(canvas, 0, 0)
+    }
+  })
+  const pngImageData = mapCanvas.toDataURL().replace(/^data:image\/png;base64,/, '')
+  ipcRenderer.send('IPC_SHARE_PNG', pngImageData)
+}
+
+export default map => {
+  evented.on('SHARE_PNG', () => {
+    pngExport(map)
+  })
+}


### PR DESCRIPTION
PR allows users to export the current view including all visible layers to a png file. 
<img width="57" alt="image" src="https://user-images.githubusercontent.com/38359572/83359414-64297e80-a37a-11ea-90bf-ce65d0b51814.png">
