### PR TITLE
replace ready-to-show event with await

### DIFF
--- a/src/main/bootstrap.js
+++ b/src/main/bootstrap.js
@@ -102,20 +102,18 @@ const createProjectWindow = async (options) => {
     i18n.on('languageChanged', languageChangedHandler)
     window.on('close', () => i18n.off('languageChanged', languageChangedHandler))
 
-    window.once('ready-to-show', () => {
-      window.show()
-      /*  Remember this window/project to be the most recent.
-          We will use this key to identify the recent project and
-          use it on startup ('app-ready') and when we switch projects ('IPC_SWITCH_PROJECT').
-      */
-      merge(RECENT_WINDOW_KEY)(() => projectOptions.path)
-    })
-
     /* (re)establish electron's normal "quit the app if no more windows are open" behavior */
     appShallQuit = true
     /* allow users to find their recently used projects access by data/time */
     projects.mergeMetadata(projectOptions.path, { lastAccess: new Date() })
-    window.loadURL(windowUrl)
+
+    /*  Remember this window/project to be the most recent.
+          We will use this key to identify the recent project and
+          use it on startup ('app-ready') and when we switch projects ('IPC_SWITCH_PROJECT').
+      */
+    merge(RECENT_WINDOW_KEY)(() => projectOptions.path)
+    await window.loadURL(windowUrl)
+    window.show()
   }
 
   if (options && options.path && projects.exists(options.path)) {


### PR DESCRIPTION
When running on Windows 10 Electron does not fire the ```ready-to-show``` event. Within the handler for this event we persisted the recent project settings. Since the settings did not get persisted we created a new 'untitled project' on every startup.

This PR fixes the issue by ignoring the ```ready-to-show``` event and waiting for [browserWindow.loadURL(...)](https://www.electronjs.org/docs/api/browser-window#winloadurlurl-options) being resolved. In fact this is the same as handling the [did-finish-load](https://www.electronjs.org/docs/api/web-contents#event-did-finish-load) event.