### PR TITLE
import layer (drag-and-drop) from and export layer to filesystem

### DIFF
--- a/src/i18n/de/electron.json
+++ b/src/i18n/de/electron.json
@@ -46,8 +46,8 @@
   },
   "export": {
     "title": "Export {{name}}",
-    "succeeded": "Export war erfolgreich: {{name}}",
-    "failed": "Export ist fehlgeschlagen: {{name}}",
+    "succeeded": "Export war erfolgreich",
+    "failed": "Export ist fehlgeschlagen",
     "clickToOpen": "Öffnen: {{path}}"
   },
   "importProject": {

--- a/src/i18n/en/electron.json
+++ b/src/i18n/en/electron.json
@@ -46,8 +46,8 @@
   },
   "export": {
     "title": "Export {{name}}",
-    "succeeded": "Export succeeded: {{name}}",
-    "failed": "Export failed: {{name}}",
+    "succeeded": "Export succeeded",
+    "failed": "Export failed",
     "clickToOpen": "Open: {{path}}"
   },
   "importProject": {

--- a/src/main/bootstrap.js
+++ b/src/main/bootstrap.js
@@ -4,6 +4,7 @@ import { app, BrowserWindow, ipcMain, dialog } from 'electron'
 import settings from 'electron-settings'
 import projects from '../shared/projects'
 import { exportProject, importProject } from './ipc/share-project'
+import { exportLayer } from './ipc/share-layer'
 import { viewAsPng } from './ipc/share-view'
 import handleCreatePreview from './ipc/create-preview'
 import i18n from '../i18n'
@@ -191,6 +192,8 @@ const bootstrap = () => {
   /* emitted by renderer/components/Management.js */
   ipcMain.on('IPC_EXPORT_PROJECT', exportProject)
   ipcMain.on('IPC_IMPORT_PROJECT', importProject)
+
+  ipcMain.on('IPC_EXPORT_LAYER', exportLayer)
 
   /* share view */
   ipcMain.on('IPC_SHARE_PNG', viewAsPng)

--- a/src/main/ipc/save-file-dialog.js
+++ b/src/main/ipc/save-file-dialog.js
@@ -1,0 +1,25 @@
+import { dialog, Notification, shell } from 'electron'
+import i18n from '../../i18n'
+
+export default (parentWindow, dialogOptions, action) => {
+  dialog.showSaveDialog(parentWindow, dialogOptions).then(async result => {
+    if (result.canceled) return
+    try {
+      await action(result.filePath)
+      const n = new Notification({
+        title: i18n.t('export.succeeded'),
+        body: i18n.t('export.clickToOpen', { path: result.filePath })
+      })
+      n.once('click', () => {
+        shell.showItemInFolder(result.filePath)
+      })
+      n.show()
+    } catch (error) {
+      const n = new Notification({
+        title: i18n.t('export.failed'),
+        body: error.message
+      })
+      n.show()
+    }
+  })
+}

--- a/src/main/ipc/share-layer.js
+++ b/src/main/ipc/share-layer.js
@@ -1,8 +1,8 @@
-import { dialog, Notification, shell } from 'electron'
+
 import sanitizeFilename from 'sanitize-filename'
 import fs from 'fs'
 import i18n from '../../i18n'
-
+import saveFileDialog from './save-file-dialog'
 
 export const exportLayer = (event, name, contents) => {
   const filenameSuggestion = sanitizeFilename(`${name}.json`)
@@ -11,25 +11,7 @@ export const exportLayer = (event, name, contents) => {
     defaultPath: filenameSuggestion,
     filters: [{ name: 'Layer', extensions: ['json'] }]
   }
+  const action = async (targetPath) => fs.promises.writeFile(targetPath, JSON.stringify(contents))
 
-  dialog.showSaveDialog(event.sender.getOwnerBrowserWindow(), dialogOptions).then(async result => {
-    if (result.canceled) return
-    try {
-      await fs.promises.writeFile(result.filePath, JSON.stringify(contents))
-      const n = new Notification({
-        title: i18n.t('export.succeeded', { name: name }),
-        body: i18n.t('export.clickToOpen', { path: result.filePath })
-      })
-      n.once('click', () => {
-        shell.showItemInFolder(result.filePath)
-      })
-      n.show()
-    } catch (error) {
-      const n = new Notification({
-        title: i18n.t('export.failed', { name: name }),
-        body: error.message
-      })
-      n.show()
-    }
-  })
+  saveFileDialog(event.sender.getOwnerBrowserWindow(), dialogOptions, action)
 }

--- a/src/main/ipc/share-layer.js
+++ b/src/main/ipc/share-layer.js
@@ -1,0 +1,35 @@
+import { dialog, Notification, shell } from 'electron'
+import sanitizeFilename from 'sanitize-filename'
+import fs from 'fs'
+import i18n from '../../i18n'
+
+
+export const exportLayer = (event, name, contents) => {
+  const filenameSuggestion = sanitizeFilename(`${name}.json`)
+  const dialogOptions = {
+    title: i18n.t('export.title', { name: name }),
+    defaultPath: filenameSuggestion,
+    filters: [{ name: 'Layer', extensions: ['json'] }]
+  }
+
+  dialog.showSaveDialog(event.sender.getOwnerBrowserWindow(), dialogOptions).then(async result => {
+    if (result.canceled) return
+    try {
+      await fs.promises.writeFile(result.filePath, JSON.stringify(contents))
+      const n = new Notification({
+        title: i18n.t('export.succeeded', { name: name }),
+        body: i18n.t('export.clickToOpen', { path: result.filePath })
+      })
+      n.once('click', () => {
+        shell.showItemInFolder(result.filePath)
+      })
+      n.show()
+    } catch (error) {
+      const n = new Notification({
+        title: i18n.t('export.failed', { name: name }),
+        body: error.message
+      })
+      n.show()
+    }
+  })
+}

--- a/src/renderer/components/layerlist/Actions.js
+++ b/src/renderer/components/layerlist/Actions.js
@@ -5,7 +5,6 @@ import Tooltip from '../Tooltip.js'
 import inputLayers from '../../project/input-layers'
 import selection from '../../selection'
 import URI from '../../project/URI'
-import { noop } from '../../../shared/combinators'
 import { useTranslation } from 'react-i18next'
 
 const withLayer = fn => {
@@ -37,8 +36,8 @@ const actions = [
   {
     icon: <ExportVariant/>,
     tooltip: 'layers.share',
-    disabled: () => true,
-    action: noop
+    disabled: layer => !layer,
+    action: () => { withLayer(layerId => inputLayers.exportLayer(layerId)) }
   }
 ]
 

--- a/src/renderer/ipc.js
+++ b/src/renderer/ipc.js
@@ -10,3 +10,8 @@ ipcRenderer.on('IPC_EDIT_DELETE', emit('EDIT_DELETE'))
 ipcRenderer.on('IPC_EDIT_CUT', emit('EDIT_CUT'))
 ipcRenderer.on('IPC_EDIT_COPY', emit('EDIT_COPY'))
 ipcRenderer.on('IPC_EDIT_PASTE', emit('EDIT_PASTE'))
+
+
+evented.on('EXPORT_LAYER', (name, contents) => {
+  ipcRenderer.send('IPC_EXPORT_LAYER', name, contents)
+})

--- a/src/renderer/map/Map.js
+++ b/src/renderer/map/Map.js
@@ -16,7 +16,9 @@ import preferences from '../project/preferences'
 import coordinateFormat from '../../shared/coord-format'
 import layers from './layers'
 import draw from './interaction/draw'
+import dropImport from './interaction/drop-import'
 import share from './share'
+
 import './style/scalebar.css'
 
 const zoom = view => view.getZoom()
@@ -60,7 +62,7 @@ const effect = props => () => {
     layers: [basemapLayerGroup(), getGridLayerGroup()],
     interactions: defaultInteractions({
       doubleClickZoom: false
-    })
+    }).extend([dropImport])
   })
 
   map.on('click', () => evented.emit('MAP_CLICKED'))

--- a/src/renderer/map/interaction/drop-import.js
+++ b/src/renderer/map/interaction/drop-import.js
@@ -7,7 +7,7 @@ const dropImportInteraction = new DragAndDrop({
 })
 dropImportInteraction.on('addfeatures', event => {
   if (!event.file || !event.features) return
-  inputLayers.importLayer(event.file.name, event.features)
+  inputLayers.importLayer(event.file.name.replace('.json', ''), event.features)
 })
 
 export default dropImportInteraction

--- a/src/renderer/map/interaction/drop-import.js
+++ b/src/renderer/map/interaction/drop-import.js
@@ -1,0 +1,13 @@
+import { GeoJSON } from 'ol/format'
+import { DragAndDrop } from 'ol/interaction'
+import inputLayers from '../../project/input-layers'
+
+const dropImportInteraction = new DragAndDrop({
+  formatConstructors: [GeoJSON]
+})
+dropImportInteraction.on('addfeatures', event => {
+  if (!event.file || !event.features) return
+  inputLayers.importLayer(event.file.name, event.features)
+})
+
+export default dropImportInteraction

--- a/src/renderer/project/input-layers.js
+++ b/src/renderer/project/input-layers.js
@@ -136,6 +136,7 @@ const writeFeatures = xs =>
     .filter(uniq)
     .map(layerId => ({ name: layerName(layerId), features: layerFeatures(layerId) }))
     // TODO: remove feature id property before write
+    // this also affects the exportLayer function
     .map(({ name, features }) => ({ name, contents: geoJSON.writeFeatures(features) }))
     .forEach(({ name, contents }) => io.writeLayer(name, contents))
 
@@ -366,7 +367,14 @@ const removeFeatures = featureIds => {
  * addFeatures :: [[string]] -> unit
  */
 const addFeatures = content => {
-  const additions = content.map(json => geoJSON.readFeature(json))
+  const additions = content.map(candidate => {
+    /*
+      When adding features to a layer via the drag-and-drop import handler
+      OL already creates features for us.
+    */
+    if (candidate instanceof ol.Feature) return candidate
+    return geoJSON.readFeature(candidate)
+  })
 
   // Add features to active layer if defined.
   additions.forEach(feature => feature.set('layerId', activeLayer().id))
@@ -478,17 +486,18 @@ const removeLayer =
     undo.applyAndPush(unlinkLayerCommand(layerId))
 
 /**
- * createLayer :: () -> unit
+ * createLayer :: () -> string
  */
 const createLayer = () => {
   const name = disambiguateLayerName('New Layer')
   const contents = '{"type":"FeatureCollection","features":[]}'
-
+  const layerId = URI.layerId()
   undo.applyAndPush(writeLayerCommand(
-    URI.layerId(),
+    layerId,
     name,
     contents
   ))
+  return layerId
 }
 
 /**
@@ -502,6 +511,14 @@ const duplicateLayer = layerId => {
     disambiguateLayerName(name),
     contents
   ))
+}
+
+const importLayer = (sourceName, features) => {
+  const layerId = createLayer()
+  const layerName = disambiguateLayerName(sourceName)
+  renameLayer(layerId, layerName)
+  activateLayer(layerId)
+  addFeatures(features)
 }
 
 /**
@@ -676,6 +693,7 @@ export default {
   createLayer,
   duplicateLayer,
   exportLayer,
+  importLayer,
   layerProperties,
   featureProperties,
   updateFeatureProperties

--- a/src/renderer/project/input-layers.js
+++ b/src/renderer/project/input-layers.js
@@ -545,6 +545,21 @@ const updateFeatureProperties = (featureId, properties) => {
   emit({ type: 'featurepropertiesupdated', featureId, properties })
 }
 
+const exportLayer = layerId => {
+  const name = layerName(layerId)
+  const contents = JSON.parse(io.readLayer(name))
+  const removeIds = feature => {
+    delete feature.id
+    delete feature.properties.layerId
+    return feature
+  }
+  const sanitizedContents = {
+    type: 'FeatureCollection',
+    features: contents.features.map(removeIds)
+  }
+  evented.emit('EXPORT_LAYER', name, sanitizedContents)
+}
+
 /**
  * Featre clipboard ops.
  */
@@ -660,6 +675,7 @@ export default {
   removeLayer,
   createLayer,
   duplicateLayer,
+  exportLayer,
   layerProperties,
   featureProperties,
   updateFeatureProperties

--- a/src/renderer/project/input-layers.js
+++ b/src/renderer/project/input-layers.js
@@ -513,6 +513,10 @@ const duplicateLayer = layerId => {
   ))
 }
 
+/**
+ * @param {string} sourceName The name of the source will become the name of the new layer
+ * @param {[ol/Feature]} features A collection of OL features
+ */
 const importLayer = (sourceName, features) => {
   const layerId = createLayer()
   const layerName = disambiguateLayerName(sourceName)


### PR DESCRIPTION
PR introduces the ability to export a layer to the filesystem. Exporting is done via the Layers panel. Select a layer and choose the ```share``` action button. This also closes #311 (missing i18n key for exportProject.title).
![image](https://user-images.githubusercontent.com/38359572/88529207-f3ac8000-cfff-11ea-8b93-d87f8229dcdb.png)
