### PR TITLE
0.6.0/lunr

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11151,6 +11151,11 @@
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
+    "memoize-one": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
+      "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
+    },
     "memory-fs": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
@@ -13284,6 +13289,15 @@
         "dom-helpers": "^5.0.1",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
+      }
+    },
+    "react-window": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.5.tgz",
+      "integrity": "sha512-HeTwlNa37AFa8MDZFZOKcNEkuF2YflA0hpGPiTT9vR7OawEt+GZbfM6wqkBahD3D3pUjIabQYzsnY/BSJbgq6Q==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
       }
     },
     "read-config-file": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11054,6 +11054,11 @@
         "yallist": "^3.0.2"
       }
     },
+    "lunr": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.8.tgz",
+      "integrity": "sha512-oxMeX/Y35PNFuZoHp+jUj5OSEmLCaIH4KTFJh7a93cHBoFmpw2IoPs22VIz7vyO2YUnx2Tn9dzIwO2P/4quIRg=="
+    },
     "luxon": {
       "version": "1.22.2",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.22.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10940,11 +10940,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
-    "lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
-    },
     "lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10940,6 +10940,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+    },
     "lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "react-dnd-html5-backend": "^10.0.2",
     "react-dom": "^16.13.1",
     "react-i18next": "^11.3.4",
+    "react-window": "^1.8.5",
     "sanitize-filename": "^1.6.3",
     "typeface-roboto": "0.0.75",
     "uuid-random": "^1.3.0"

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "geographiclib": "^1.50.0",
     "i18next": "^19.3.4",
     "immutable": "^4.0.0-rc.12",
-    "lodash.debounce": "^4.0.8",
     "lodash.throttle": "^4.1.1",
     "luxon": "^1.22.2",
     "mathjs": "^6.6.2",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "i18next": "^19.3.4",
     "immutable": "^4.0.0-rc.12",
     "lodash.throttle": "^4.1.1",
+    "lunr": "^2.3.8",
     "luxon": "^1.22.2",
     "mathjs": "^6.6.2",
     "mdi-material-ui": "^6.13.0",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "geographiclib": "^1.50.0",
     "i18next": "^19.3.4",
     "immutable": "^4.0.0-rc.12",
+    "lodash.debounce": "^4.0.8",
     "lodash.throttle": "^4.1.1",
     "luxon": "^1.22.2",
     "mathjs": "^6.6.2",

--- a/src/i18n/de/web.json
+++ b/src/i18n/de/web.json
@@ -68,6 +68,9 @@
     },
     "search": {
       "placeholder": "Suche nach unit, radar, missile, ..."
+    },
+    "featureList": {
+      "noResults": "Keine Ergebnisse. Bitte ändern Sie die Such- bzw. Filterkriterien"
     }
   }
 }

--- a/src/i18n/en/web.json
+++ b/src/i18n/en/web.json
@@ -68,6 +68,9 @@
     },
     "search": {
       "placeholder": "Search for unit, radar, missile, ..."
+    },
+    "featureList": {
+      "noResults": "No results. Please change the search or filter criteria."
     }
   }
 }

--- a/src/renderer/components/Activities.js
+++ b/src/renderer/components/Activities.js
@@ -123,6 +123,8 @@ const Activities = (/* props */) => {
 
   const toolPanel = () => activeTool ? activeTool.panel() : null
 
+  console.log('toolPanel', toolPanel())
+
   return (
     <>
       <ActivityBar activities={activities} activeTool={activeTool} onActivitySelected={handleActivitySelected}/>

--- a/src/renderer/components/SIDC.js
+++ b/src/renderer/components/SIDC.js
@@ -1,4 +1,6 @@
+const SCHEMA = 0
 const HOSTILITY = 1
+const BATTLEDIMENSION = 2
 const STATUS = 3
 const MODIFIER = 10
 const MOBILITY = 10
@@ -16,7 +18,9 @@ const part = (index, n = 1, replaceWildcard = true) => {
   }
 }
 
+export const schemaPart = part(SCHEMA)
 export const hostilityPart = part(HOSTILITY)
+export const battleDimensionPart = part(BATTLEDIMENSION)
 export const statusPart = part(STATUS)
 export const modifierPart = part(MODIFIER)
 export const mobilityPart = part(MOBILITY, 2, true)

--- a/src/renderer/components/feature-descriptors.js
+++ b/src/renderer/components/feature-descriptors.js
@@ -84,6 +84,6 @@ export const featureDescriptors = (filter, preset = {}) => {
   const matches = sortedList
     .filter(match)
     .map(updateSIDC)
-  console.log('## matches', matches.length)
-  return matches // R.take(50, matches)
+  // console.log('## matches', matches.length)
+  return matches
 }

--- a/src/renderer/components/feature-descriptors.js
+++ b/src/renderer/components/feature-descriptors.js
@@ -1,7 +1,14 @@
 import * as R from 'ramda'
 import descriptors from './feature-descriptors.json'
 import { K } from '../../shared/combinators'
-import { parameterized, hostilityPart, statusPart, installationPart } from './SIDC'
+import {
+  parameterized,
+  schemaPart,
+  hostilityPart,
+  // battleDimensionPart,
+  statusPart,
+  installationPart
+} from './SIDC'
 
 const lookup = descriptors.reduce((acc, descriptor) => K(acc)(acc => {
   const sidc = parameterized(descriptor.sidc)
@@ -45,15 +52,23 @@ export const featureGeometry = sidc => {
  * featureDescriptors :: () => [object]
  */
 export const featureDescriptors = (filter, preset = {}) => {
-  if (!filter || filter.length < 3) return []
+  // if (!filter || filter.length < 3) return []
 
+  const schema = preset.schema || 'S'
   const hostlility = preset.hostility || 'F'
+  // const battleDimension = preset.battleDimension || 'G'
   const status = preset.status || 'P'
   const installation = preset.installation || '-'
 
+  const schemaMatch = descr => schemaPart.value(descr.sidc) === schema
+  // const battleDimensionMatch = descr => battleDimensionPart.value(descr.sidc) === battleDimension
   const filterMatch = descr => descr.sortkey.includes(filter.toLowerCase())
   const installationMatch = descr => [installation, '*'].includes(installationPart.value(descr.sidc))
-  const match = descr => filterMatch(descr) && installationMatch(descr)
+  const match = descr =>
+    schemaMatch(descr) &&
+    // battleDimensionMatch(descr) &&
+    filterMatch(descr) &&
+    installationMatch(descr)
 
   const installationModifier = sidc => installationPart.value(sidc) !== '*'
     ? sidc
@@ -69,5 +84,6 @@ export const featureDescriptors = (filter, preset = {}) => {
   const matches = sortedList
     .filter(match)
     .map(updateSIDC)
-  return R.take(50, matches)
+  console.log('## matches', matches.length)
+  return matches // R.take(50, matches)
 }

--- a/src/renderer/components/feature-descriptors.js
+++ b/src/renderer/components/feature-descriptors.js
@@ -5,7 +5,7 @@ import {
   parameterized,
   schemaPart,
   hostilityPart,
-  // battleDimensionPart,
+  battleDimensionPart,
   statusPart,
   installationPart
 } from './SIDC'
@@ -52,21 +52,20 @@ export const featureGeometry = sidc => {
  * featureDescriptors :: () => [object]
  */
 export const featureDescriptors = (filter, preset = {}) => {
-  // if (!filter || filter.length < 3) return []
 
   const schema = preset.schema || 'S'
   const hostlility = preset.hostility || 'F'
-  // const battleDimension = preset.battleDimension || 'G'
+  const battleDimension = preset.battleDimension || []
   const status = preset.status || 'P'
   const installation = preset.installation || '-'
 
   const schemaMatch = descr => schemaPart.value(descr.sidc) === schema
-  // const battleDimensionMatch = descr => battleDimensionPart.value(descr.sidc) === battleDimension
+  const battleDimensionMatch = descr => battleDimension.length ? battleDimension.includes(battleDimensionPart.value(descr.sidc)) : true
   const filterMatch = descr => descr.sortkey.includes(filter.toLowerCase())
   const installationMatch = descr => [installation, '*'].includes(installationPart.value(descr.sidc))
   const match = descr =>
     schemaMatch(descr) &&
-    // battleDimensionMatch(descr) &&
+    battleDimensionMatch(descr) &&
     filterMatch(descr) &&
     installationMatch(descr)
 

--- a/src/renderer/components/feature-descriptors.js
+++ b/src/renderer/components/feature-descriptors.js
@@ -1,13 +1,11 @@
 import * as R from 'ramda'
 import descriptors from './feature-descriptors.json'
 import { K } from '../../shared/combinators'
+import lunr from 'lunr'
 import {
   parameterized,
-  schemaPart,
   hostilityPart,
-  battleDimensionPart,
-  statusPart,
-  installationPart
+  statusPart
 } from './SIDC'
 
 const lookup = descriptors.reduce((acc, descriptor) => K(acc)(acc => {
@@ -30,10 +28,36 @@ const sortedList = descriptors
     geometry: descriptor.geometry,
     ...descriptor.parameters,
     name: descriptor.hierarchy[descriptor.hierarchy.length - 1],
-    hierarchy: R.take(descriptor.hierarchy.length - 2, R.drop(1, descriptor.hierarchy)).join(', '),
+    hierarchy: R.take(descriptor.hierarchy.length - 1, descriptor.hierarchy).join(', '),
     sortkey: descriptor.hierarchy.join(', ').toLowerCase()
   }))
   .sort((a, b) => a.sortkey.localeCompare(b.sortkey))
+
+const document = ({ sidc, hierarchy, scope, dimension }) => ({
+  sidc,
+  title: hierarchy[hierarchy.length - 1],
+  body: R.take(hierarchy.length - 1, hierarchy).join(' '),
+  scope,
+  dimension
+})
+
+const index = lunr(function () {
+  // TODO: remove 'so' (stability operations) from stop word list.
+  // Stemmer makes more harm than good in our case.
+  this.pipeline.remove(lunr.stemmer)
+  this.searchPipeline.remove(lunr.stemmer)
+
+  this.metadataWhitelist = ['position']
+  this.ref('sidc')
+  this.field('title')
+  this.field('body')
+  this.field('scope')
+  this.field('dimension')
+
+  descriptors
+    .map(document)
+    .forEach(document => this.add(document))
+})
 
 /**
  * featureClass :: string -> string
@@ -52,37 +76,21 @@ export const featureGeometry = sidc => {
  * featureDescriptors :: () => [object]
  */
 export const featureDescriptors = (filter, preset = {}) => {
-
-  const schema = preset.schema || 'S'
   const hostlility = preset.hostility || 'F'
-  const battleDimension = preset.battleDimension || []
   const status = preset.status || 'P'
-  const installation = preset.installation || '-'
-
-  const schemaMatch = descr => schemaPart.value(descr.sidc) === schema
-  const battleDimensionMatch = descr => battleDimension.length ? battleDimension.includes(battleDimensionPart.value(descr.sidc)) : true
-  const filterMatch = descr => descr.sortkey.includes(filter.toLowerCase())
-  const installationMatch = descr => [installation, '*'].includes(installationPart.value(descr.sidc))
-  const match = descr =>
-    schemaMatch(descr) &&
-    battleDimensionMatch(descr) &&
-    filterMatch(descr) &&
-    installationMatch(descr)
-
-  const installationModifier = sidc => installationPart.value(sidc) !== '*'
-    ? sidc
-    : installationPart.replace(installation)(sidc)
-
   const sidc = R.compose(
-    installationModifier,
     hostilityPart.replace(hostlility),
     statusPart.replace(status)
   )
 
   const updateSIDC = descriptor => ({ ...descriptor, sidc: sidc(descriptor.sidc) })
-  const matches = sortedList
-    .filter(match)
-    .map(updateSIDC)
-  // console.log('## matches', matches.length)
-  return matches
+
+  try {
+    return index.search(filter)
+      .map(item => sortedList.find(descriptor => descriptor.sidc === item.ref))
+      .map(updateSIDC)
+  } catch (err) {
+    console.error(err)
+    return []
+  }
 }

--- a/src/renderer/components/feature-descriptors.json
+++ b/src/renderer/components/feature-descriptors.json
@@ -2,7 +2,9 @@
   {
     "sidc": "E*F*A-----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "AGRICULTURE AND FOOD INFRASTRUCTURE"
@@ -11,7 +13,9 @@
   {
     "sidc": "E*F*AA----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "AGRICULTURE AND FOOD INFRASTRUCTURE",
@@ -21,7 +25,9 @@
   {
     "sidc": "E*F*AB----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "AGRICULTURE AND FOOD INFRASTRUCTURE",
@@ -31,7 +37,9 @@
   {
     "sidc": "E*F*AC----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "AGRICULTURE AND FOOD INFRASTRUCTURE",
@@ -41,7 +49,9 @@
   {
     "sidc": "E*F*AD----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "AGRICULTURE AND FOOD INFRASTRUCTURE",
@@ -51,7 +61,9 @@
   {
     "sidc": "E*F*AE----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "AGRICULTURE AND FOOD INFRASTRUCTURE",
@@ -61,7 +73,9 @@
   {
     "sidc": "E*F*AF----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "AGRICULTURE AND FOOD INFRASTRUCTURE",
@@ -71,7 +85,9 @@
   {
     "sidc": "E*F*AG----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "AGRICULTURE AND FOOD INFRASTRUCTURE",
@@ -81,7 +97,9 @@
   {
     "sidc": "E*F*B-----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "BANKING FINANCE AND INSURANCE INFRASTRUCTURE"
@@ -90,7 +108,9 @@
   {
     "sidc": "E*F*BA----*****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "BANKING FINANCE AND INSURANCE INFRASTRUCTURE",
@@ -100,7 +120,9 @@
   {
     "sidc": "E*F*BB----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "BANKING FINANCE AND INSURANCE INFRASTRUCTURE",
@@ -110,7 +132,9 @@
   {
     "sidc": "E*F*BC----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "BANKING FINANCE AND INSURANCE INFRASTRUCTURE",
@@ -120,7 +144,9 @@
   {
     "sidc": "E*F*BD----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "BANKING FINANCE AND INSURANCE INFRASTRUCTURE",
@@ -130,7 +156,9 @@
   {
     "sidc": "E*F*BE----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "BANKING FINANCE AND INSURANCE INFRASTRUCTURE",
@@ -140,7 +168,9 @@
   {
     "sidc": "E*F*BF----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "BANKING FINANCE AND INSURANCE INFRASTRUCTURE",
@@ -150,7 +180,9 @@
   {
     "sidc": "E*F*C-----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "COMMERCIAL INFRASTRUCTURE"
@@ -159,7 +191,9 @@
   {
     "sidc": "E*F*CA----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "COMMERCIAL INFRASTRUCTURE",
@@ -169,7 +203,9 @@
   {
     "sidc": "E*F*CB----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "COMMERCIAL INFRASTRUCTURE",
@@ -179,7 +215,9 @@
   {
     "sidc": "E*F*CC----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "COMMERCIAL INFRASTRUCTURE",
@@ -189,7 +227,9 @@
   {
     "sidc": "E*F*CD----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "COMMERCIAL INFRASTRUCTURE",
@@ -199,7 +239,9 @@
   {
     "sidc": "E*F*CE----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "COMMERCIAL INFRASTRUCTURE",
@@ -209,7 +251,9 @@
   {
     "sidc": "E*F*CF----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "COMMERCIAL INFRASTRUCTURE",
@@ -219,7 +263,9 @@
   {
     "sidc": "E*F*CG----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "COMMERCIAL INFRASTRUCTURE",
@@ -229,7 +275,9 @@
   {
     "sidc": "E*F*CH----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "COMMERCIAL INFRASTRUCTURE",
@@ -239,7 +287,9 @@
   {
     "sidc": "E*F*CI----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "COMMERCIAL INFRASTRUCTURE",
@@ -249,7 +299,9 @@
   {
     "sidc": "E*F*CJ----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "COMMERCIAL INFRASTRUCTURE",
@@ -259,7 +311,9 @@
   {
     "sidc": "E*F*D-----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "EDUCATIONAL FACILITIES INFRASTRUCTURE"
@@ -268,7 +322,9 @@
   {
     "sidc": "E*F*DA----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "EDUCATIONAL FACILITIES INFRASTRUCTURE",
@@ -278,7 +334,9 @@
   {
     "sidc": "E*F*DB----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "EDUCATIONAL FACILITIES INFRASTRUCTURE",
@@ -288,7 +346,9 @@
   {
     "sidc": "E*F*EA----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "ENERGY FACILITIES INFRASTRUCTURE",
@@ -298,7 +358,9 @@
   {
     "sidc": "E*F*EB----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "ENERGY FACILITIES INFRASTRUCTURE",
@@ -308,7 +370,9 @@
   {
     "sidc": "E*F*EE----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "ENERGY FACILITIES INFRASTRUCTURE",
@@ -318,7 +382,9 @@
   {
     "sidc": "E*F*F-----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "GOVERNMENT SITE INFRASTRUCTURE"
@@ -327,7 +393,9 @@
   {
     "sidc": "E*F*G-----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "MILITARY INFRASTRUCTURE"
@@ -336,7 +404,9 @@
   {
     "sidc": "E*F*GA----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "MILITARY INFRASTRUCTURE",
@@ -346,7 +416,9 @@
   {
     "sidc": "E*F*H-----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "POSTAL SERVICE INFRASTRUCTURE"
@@ -355,7 +427,9 @@
   {
     "sidc": "E*F*HA----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "POSTAL SERVICE INFRASTRUCTURE",
@@ -365,7 +439,9 @@
   {
     "sidc": "E*F*HB----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "POSTAL SERVICE INFRASTRUCTURE",
@@ -375,7 +451,9 @@
   {
     "sidc": "E*F*I-----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "PUBLIC VENUES INFRASTRUCTURE"
@@ -384,7 +462,9 @@
   {
     "sidc": "E*F*IA----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "PUBLIC VENUES INFRASTRUCTURE",
@@ -394,7 +474,9 @@
   {
     "sidc": "E*F*IB----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "PUBLIC VENUES INFRASTRUCTURE",
@@ -404,7 +486,9 @@
   {
     "sidc": "E*F*IC----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "PUBLIC VENUES INFRASTRUCTURE",
@@ -414,7 +498,9 @@
   {
     "sidc": "E*F*ID----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "PUBLIC VENUES INFRASTRUCTURE",
@@ -424,7 +510,9 @@
   {
     "sidc": "E*F*J-----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "SPECIAL NEEDS INFRASTRUCTURE"
@@ -433,7 +521,9 @@
   {
     "sidc": "E*F*JA----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "SPECIAL NEEDS INFRASTRUCTURE",
@@ -443,7 +533,9 @@
   {
     "sidc": "E*F*JB----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "SPECIAL NEEDS INFRASTRUCTURE",
@@ -453,7 +545,9 @@
   {
     "sidc": "E*F*JC----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "SPECIAL NEEDS INFRASTRUCTURE",
@@ -463,7 +557,9 @@
   {
     "sidc": "E*F*K-----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "TELECOMMUNICATIONS INFRASTRUCTURE"
@@ -472,7 +568,9 @@
   {
     "sidc": "E*F*KB----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "TELECOMMUNICATIONS INFRASTRUCTURE",
@@ -482,7 +580,9 @@
   {
     "sidc": "E*F*LA----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "TRANSPORTATION INFRASTRUCTURE",
@@ -492,7 +592,9 @@
   {
     "sidc": "E*F*LD----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "TRANSPORTATION INFRASTRUCTURE",
@@ -502,7 +604,9 @@
   {
     "sidc": "E*F*LE----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "TRANSPORTATION INFRASTRUCTURE",
@@ -512,7 +616,9 @@
   {
     "sidc": "E*F*LF----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "TRANSPORTATION INFRASTRUCTURE",
@@ -522,7 +628,9 @@
   {
     "sidc": "E*F*LH----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "TRANSPORTATION INFRASTRUCTURE",
@@ -532,7 +640,9 @@
   {
     "sidc": "E*F*LJ----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "TRANSPORTATION INFRASTRUCTURE",
@@ -542,7 +652,9 @@
   {
     "sidc": "E*F*LK----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "TRANSPORTATION INFRASTRUCTURE",
@@ -552,7 +664,9 @@
   {
     "sidc": "E*F*LM----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "TRANSPORTATION INFRASTRUCTURE",
@@ -562,7 +676,9 @@
   {
     "sidc": "E*F*LO----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "TRANSPORTATION INFRASTRUCTURE",
@@ -572,7 +688,9 @@
   {
     "sidc": "E*F*LP----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "TRANSPORTATION INFRASTRUCTURE",
@@ -582,7 +700,9 @@
   {
     "sidc": "E*F*MA----*****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "WATER SUPPLY INFRASTRUCTURE",
@@ -592,7 +712,9 @@
   {
     "sidc": "E*F*MB----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "WATER SUPPLY INFRASTRUCTURE",
@@ -602,7 +724,9 @@
   {
     "sidc": "E*F*MC----*****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "WATER SUPPLY INFRASTRUCTURE",
@@ -612,7 +736,9 @@
   {
     "sidc": "E*F*MD----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "WATER SUPPLY INFRASTRUCTURE",
@@ -622,7 +748,9 @@
   {
     "sidc": "E*F*ME----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "WATER SUPPLY INFRASTRUCTURE",
@@ -632,7 +760,9 @@
   {
     "sidc": "E*F*MF----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "WATER SUPPLY INFRASTRUCTURE",
@@ -642,7 +772,9 @@
   {
     "sidc": "E*F*MG----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "WATER SUPPLY INFRASTRUCTURE",
@@ -652,7 +784,9 @@
   {
     "sidc": "E*F*MH----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "WATER SUPPLY INFRASTRUCTURE",
@@ -662,7 +796,9 @@
   {
     "sidc": "E*F*MI----H****",
     "class": "EI",
+    "scope": "INSTALLATION",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "WATER SUPPLY INFRASTRUCTURE",
@@ -672,7 +808,9 @@
   {
     "sidc": "E*I*A-----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "CIVIL DISTURBANCE INCIDENT"
@@ -681,7 +819,9 @@
   {
     "sidc": "E*I*AC----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "CIVIL DISTURBANCE INCIDENT",
@@ -691,7 +831,9 @@
   {
     "sidc": "E*I*B-----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "CRIMINAL ACTIVITY INCIDENT"
@@ -700,7 +842,9 @@
   {
     "sidc": "E*I*BA----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "CRIMINAL ACTIVITY INCIDENT",
@@ -710,7 +854,9 @@
   {
     "sidc": "E*I*BC----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "CRIMINAL ACTIVITY INCIDENT",
@@ -720,7 +866,9 @@
   {
     "sidc": "E*I*BD----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "CRIMINAL ACTIVITY INCIDENT",
@@ -730,7 +878,9 @@
   {
     "sidc": "E*I*BF----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "CRIMINAL ACTIVITY INCIDENT",
@@ -740,7 +890,9 @@
   {
     "sidc": "E*I*C-----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "FIRE INCIDENT"
@@ -749,7 +901,9 @@
   {
     "sidc": "E*I*CA----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "FIRE INCIDENT",
@@ -759,7 +913,9 @@
   {
     "sidc": "E*I*CB----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "FIRE INCIDENT",
@@ -769,7 +925,9 @@
   {
     "sidc": "E*I*CC----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "FIRE INCIDENT",
@@ -779,7 +937,9 @@
   {
     "sidc": "E*I*CD----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "FIRE INCIDENT",
@@ -789,7 +949,9 @@
   {
     "sidc": "E*I*CE----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "FIRE INCIDENT",
@@ -799,7 +961,9 @@
   {
     "sidc": "E*I*CF----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "FIRE INCIDENT",
@@ -809,7 +973,9 @@
   {
     "sidc": "E*I*CG----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "FIRE INCIDENT",
@@ -819,7 +985,9 @@
   {
     "sidc": "E*I*CH----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "FIRE INCIDENT",
@@ -829,7 +997,9 @@
   {
     "sidc": "E*I*D-----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "HAZARDOUS MATERIAL INCIDENT"
@@ -838,7 +1008,9 @@
   {
     "sidc": "E*I*DA----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "HAZARDOUS MATERIAL INCIDENT",
@@ -848,7 +1020,9 @@
   {
     "sidc": "E*I*DB----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "HAZARDOUS MATERIAL INCIDENT",
@@ -858,7 +1032,9 @@
   {
     "sidc": "E*I*DC----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "HAZARDOUS MATERIAL INCIDENT",
@@ -868,7 +1044,9 @@
   {
     "sidc": "E*I*DD----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "HAZARDOUS MATERIAL INCIDENT",
@@ -878,7 +1056,9 @@
   {
     "sidc": "E*I*DE----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "HAZARDOUS MATERIAL INCIDENT",
@@ -888,7 +1068,9 @@
   {
     "sidc": "E*I*DF----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "HAZARDOUS MATERIAL INCIDENT",
@@ -898,7 +1080,9 @@
   {
     "sidc": "E*I*DG----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "HAZARDOUS MATERIAL INCIDENT",
@@ -908,7 +1092,9 @@
   {
     "sidc": "E*I*DH----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "HAZARDOUS MATERIAL INCIDENT",
@@ -918,7 +1104,9 @@
   {
     "sidc": "E*I*DI----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "HAZARDOUS MATERIAL INCIDENT",
@@ -928,7 +1116,9 @@
   {
     "sidc": "E*I*DJ----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "HAZARDOUS MATERIAL INCIDENT",
@@ -938,7 +1128,9 @@
   {
     "sidc": "E*I*DK----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "HAZARDOUS MATERIAL INCIDENT",
@@ -948,7 +1140,9 @@
   {
     "sidc": "E*I*DL----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "HAZARDOUS MATERIAL INCIDENT",
@@ -958,7 +1152,9 @@
   {
     "sidc": "E*I*DM----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "HAZARDOUS MATERIAL INCIDENT",
@@ -968,7 +1164,9 @@
   {
     "sidc": "E*I*DN----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "HAZARDOUS MATERIAL INCIDENT",
@@ -978,7 +1176,9 @@
   {
     "sidc": "E*I*E-----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "AIR INCIDENT"
@@ -987,7 +1187,9 @@
   {
     "sidc": "E*I*EA----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "AIR INCIDENT",
@@ -997,7 +1199,9 @@
   {
     "sidc": "E*I*F-----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "MARINE INCIDENT"
@@ -1006,7 +1210,9 @@
   {
     "sidc": "E*I*FA----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "MARINE INCIDENT",
@@ -1016,7 +1222,9 @@
   {
     "sidc": "E*I*G-----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "RAIL INCIDENT"
@@ -1025,7 +1233,9 @@
   {
     "sidc": "E*I*GA----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "RAIL INCIDENT",
@@ -1035,7 +1245,9 @@
   {
     "sidc": "E*I*GB----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "RAIL INCIDENT",
@@ -1045,7 +1257,9 @@
   {
     "sidc": "E*I*H-----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "VEHICLE INCIDENT"
@@ -1054,7 +1268,9 @@
   {
     "sidc": "E*I*HA----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "VEHICLE INCIDENT",
@@ -1064,7 +1280,9 @@
   {
     "sidc": "E*N*AA----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "NATURAL EVENTS",
@@ -1075,7 +1293,9 @@
   {
     "sidc": "E*N*AB----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "NATURAL EVENTS",
@@ -1086,7 +1306,9 @@
   {
     "sidc": "E*N*AC----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "NATURAL EVENTS",
@@ -1097,7 +1319,9 @@
   {
     "sidc": "E*N*AD----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "NATURAL EVENTS",
@@ -1108,7 +1332,9 @@
   {
     "sidc": "E*N*AE----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "NATURAL EVENTS",
@@ -1119,7 +1345,9 @@
   {
     "sidc": "E*N*AG----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "NATURAL EVENTS",
@@ -1130,7 +1358,9 @@
   {
     "sidc": "E*N*BB----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "NATURAL EVENTS",
@@ -1141,7 +1371,9 @@
   {
     "sidc": "E*N*BC----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "NATURAL EVENTS",
@@ -1152,7 +1384,9 @@
   {
     "sidc": "E*N*BF----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "NATURAL EVENTS",
@@ -1163,7 +1397,9 @@
   {
     "sidc": "E*N*BM----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "NATURAL EVENTS",
@@ -1174,7 +1410,9 @@
   {
     "sidc": "E*N*CA----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "NATURAL EVENTS",
@@ -1184,7 +1422,9 @@
   {
     "sidc": "E*N*CB----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "NATURAL EVENTS",
@@ -1194,7 +1434,9 @@
   {
     "sidc": "E*N*CC----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "NATURAL EVENTS",
@@ -1204,7 +1446,9 @@
   {
     "sidc": "E*N*CD----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "NATURAL EVENTS",
@@ -1214,7 +1458,9 @@
   {
     "sidc": "E*N*CE----*****",
     "class": "EEI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "NATURAL EVENTS",
@@ -1223,7 +1469,9 @@
   },
   {
     "sidc": "E*O*A-----*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1232,7 +1480,9 @@
   },
   {
     "sidc": "E*O*AA----*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1241,7 +1491,9 @@
   },
   {
     "sidc": "E*O*AB----*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1251,7 +1503,9 @@
   {
     "sidc": "E*O*AC----H****",
     "class": "EI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1261,7 +1515,9 @@
   {
     "sidc": "E*O*AD----H****",
     "class": "EI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1271,7 +1527,9 @@
   },
   {
     "sidc": "E*O*AE----*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1281,7 +1539,9 @@
   },
   {
     "sidc": "E*O*AF----*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1292,7 +1552,9 @@
   {
     "sidc": "E*O*AG----H****",
     "class": "EI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1303,7 +1565,9 @@
   {
     "sidc": "E*O*AJ----H****",
     "class": "EI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1314,7 +1578,9 @@
   {
     "sidc": "E*O*AK----H****",
     "class": "EI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1325,7 +1591,9 @@
   {
     "sidc": "E*O*AL----H****",
     "class": "EI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1336,7 +1604,9 @@
   {
     "sidc": "E*O*AM----H****",
     "class": "EI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1346,7 +1616,9 @@
   },
   {
     "sidc": "E*O*B-----*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1355,7 +1627,9 @@
   },
   {
     "sidc": "E*O*BA----*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1364,7 +1638,9 @@
   },
   {
     "sidc": "E*O*BB----*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1374,7 +1650,9 @@
   {
     "sidc": "E*O*BC----H****",
     "class": "EI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1383,7 +1661,9 @@
   },
   {
     "sidc": "E*O*BD----*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1394,7 +1674,9 @@
   {
     "sidc": "E*O*BE----H****",
     "class": "EI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1405,7 +1687,9 @@
   {
     "sidc": "E*O*BF----H****",
     "class": "EI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1415,7 +1699,9 @@
   {
     "sidc": "E*O*BG----H****",
     "class": "EI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1426,7 +1712,9 @@
   {
     "sidc": "E*O*BH----H****",
     "class": "EI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1437,7 +1725,9 @@
   {
     "sidc": "E*O*BI----H****",
     "class": "EI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1447,7 +1737,9 @@
   },
   {
     "sidc": "E*O*BJ----*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1458,7 +1750,9 @@
   {
     "sidc": "E*O*BK----H****",
     "class": "EI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1469,7 +1763,9 @@
   {
     "sidc": "E*O*BL----H****",
     "class": "EI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1479,7 +1775,9 @@
   },
   {
     "sidc": "E*O*C-----*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1488,7 +1786,9 @@
   },
   {
     "sidc": "E*O*CA----*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1497,7 +1797,9 @@
   },
   {
     "sidc": "E*O*CB----*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1506,7 +1808,9 @@
   },
   {
     "sidc": "E*O*CC----*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1517,7 +1821,9 @@
   {
     "sidc": "E*O*CD----H****",
     "class": "EI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1528,7 +1834,9 @@
   {
     "sidc": "E*O*CE----H****",
     "class": "EI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1538,7 +1846,9 @@
   },
   {
     "sidc": "E*O*D-----*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1547,7 +1857,9 @@
   },
   {
     "sidc": "E*O*DA----*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1556,7 +1868,9 @@
   },
   {
     "sidc": "E*O*DB----*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1566,7 +1880,9 @@
   {
     "sidc": "E*O*DC----H****",
     "class": "EI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1575,7 +1891,9 @@
   },
   {
     "sidc": "E*O*DD----*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1585,7 +1903,9 @@
   },
   {
     "sidc": "E*O*DDA---*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1595,7 +1915,9 @@
   },
   {
     "sidc": "E*O*DDB---*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1606,7 +1928,9 @@
   {
     "sidc": "E*O*DDC---H****",
     "class": "EI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1616,7 +1940,9 @@
   },
   {
     "sidc": "E*O*DE----*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1626,7 +1952,9 @@
   },
   {
     "sidc": "E*O*DEA---*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1636,7 +1964,9 @@
   },
   {
     "sidc": "E*O*DEB---*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1647,7 +1977,9 @@
   {
     "sidc": "E*O*DEC---H****",
     "class": "EI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1657,7 +1989,9 @@
   },
   {
     "sidc": "E*O*DF----*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1667,7 +2001,9 @@
   },
   {
     "sidc": "E*O*DFA---*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1677,7 +2013,9 @@
   },
   {
     "sidc": "E*O*DFB---*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1688,7 +2026,9 @@
   {
     "sidc": "E*O*DFC---H****",
     "class": "EI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1698,7 +2038,9 @@
   },
   {
     "sidc": "E*O*DG----*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1708,7 +2050,9 @@
   },
   {
     "sidc": "E*O*DGA---*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1718,7 +2062,9 @@
   },
   {
     "sidc": "E*O*DGB---*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1729,7 +2075,9 @@
   {
     "sidc": "E*O*DGC---H****",
     "class": "EI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1739,7 +2087,9 @@
   },
   {
     "sidc": "E*O*DH----*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1749,7 +2099,9 @@
   },
   {
     "sidc": "E*O*DHA---*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1759,7 +2111,9 @@
   },
   {
     "sidc": "E*O*DHB---*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1770,7 +2124,9 @@
   {
     "sidc": "E*O*DHC---H****",
     "class": "EI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1780,7 +2136,9 @@
   },
   {
     "sidc": "E*O*DI----*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1790,7 +2148,9 @@
   },
   {
     "sidc": "E*O*DIA---*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1800,7 +2160,9 @@
   },
   {
     "sidc": "E*O*DIB---*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1811,7 +2173,9 @@
   {
     "sidc": "E*O*DIC---H****",
     "class": "EI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1821,7 +2185,9 @@
   },
   {
     "sidc": "E*O*DJ----*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1831,7 +2197,9 @@
   },
   {
     "sidc": "E*O*DJB---*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1842,7 +2210,9 @@
   {
     "sidc": "E*O*DJC---H****",
     "class": "EI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1853,7 +2223,9 @@
   },
   {
     "sidc": "E*O*DK----*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1863,7 +2235,9 @@
   },
   {
     "sidc": "E*O*DL----*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1873,7 +2247,9 @@
   },
   {
     "sidc": "E*O*DLA---*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1883,7 +2259,9 @@
   },
   {
     "sidc": "E*O*DLB---*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1894,7 +2272,9 @@
   {
     "sidc": "E*O*DLC---H****",
     "class": "EI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1904,7 +2284,9 @@
   },
   {
     "sidc": "E*O*DM----*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1914,7 +2296,9 @@
   },
   {
     "sidc": "E*O*DMA---*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1924,7 +2308,9 @@
   },
   {
     "sidc": "E*O*DMB---*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1935,7 +2321,9 @@
   {
     "sidc": "E*O*DMC---H****",
     "class": "EI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1945,7 +2333,9 @@
   },
   {
     "sidc": "E*O*DN----*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1955,7 +2345,9 @@
   },
   {
     "sidc": "E*O*DNA---*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1966,7 +2358,9 @@
   {
     "sidc": "E*O*DNC---H****",
     "class": "EI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1976,7 +2370,9 @@
   },
   {
     "sidc": "E*O*DO----*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1986,7 +2382,9 @@
   },
   {
     "sidc": "E*O*DOA---*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -1996,7 +2394,9 @@
   },
   {
     "sidc": "E*O*DOB---*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -2007,7 +2407,9 @@
   {
     "sidc": "E*O*DOC---H****",
     "class": "EI",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -2017,7 +2419,9 @@
   },
   {
     "sidc": "E*O*EA----*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -2026,7 +2430,9 @@
   },
   {
     "sidc": "E*O*EB----*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -2035,7 +2441,9 @@
   },
   {
     "sidc": "E*O*EC----*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -2044,7 +2452,9 @@
   },
   {
     "sidc": "E*O*ED----*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -2053,7 +2463,9 @@
   },
   {
     "sidc": "E*O*EE----*****",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "EMS",
     "hierarchy": [
       "EMERGENCY MANAGEMENT SYMBOLS",
       "OPERATIONS",
@@ -2063,7 +2475,9 @@
   {
     "sidc": "G*F*ACAC--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Undefined",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2074,7 +2488,9 @@
   {
     "sidc": "G*F*ACAI--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2085,7 +2501,9 @@
   {
     "sidc": "G*F*ACAR--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Undefined",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2096,7 +2514,9 @@
   {
     "sidc": "G*F*ACBC--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Undefined",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2107,7 +2527,9 @@
   {
     "sidc": "G*F*ACBI--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2118,7 +2540,9 @@
   {
     "sidc": "G*F*ACBR--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Undefined",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2129,7 +2553,9 @@
   {
     "sidc": "G*F*ACDC--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Undefined",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2140,7 +2566,9 @@
   {
     "sidc": "G*F*ACDI--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2151,7 +2579,9 @@
   {
     "sidc": "G*F*ACDR--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Undefined",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2162,7 +2592,9 @@
   {
     "sidc": "G*F*ACEC--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Undefined",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2173,7 +2605,9 @@
   {
     "sidc": "G*F*ACEI--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2184,7 +2618,9 @@
   {
     "sidc": "G*F*ACER--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Undefined",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2195,7 +2631,9 @@
   {
     "sidc": "G*F*ACFC--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Undefined",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2206,7 +2644,9 @@
   {
     "sidc": "G*F*ACFI--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2217,7 +2657,9 @@
   {
     "sidc": "G*F*ACFR--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Undefined",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2228,7 +2670,9 @@
   {
     "sidc": "G*F*ACNC--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Undefined",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2240,7 +2684,9 @@
   {
     "sidc": "G*F*ACNI--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2252,7 +2698,9 @@
   {
     "sidc": "G*F*ACNR--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Undefined",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2264,7 +2712,9 @@
   {
     "sidc": "G*F*ACPC--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Undefined",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2275,7 +2725,9 @@
   {
     "sidc": "G*F*ACPR--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2286,7 +2738,9 @@
   {
     "sidc": "G*F*ACRC--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Undefined",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2297,7 +2751,9 @@
   {
     "sidc": "G*F*ACRI--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2308,7 +2764,9 @@
   {
     "sidc": "G*F*ACRR--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Undefined",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2319,7 +2777,9 @@
   {
     "sidc": "G*F*ACSC--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Undefined",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2330,7 +2790,9 @@
   {
     "sidc": "G*F*ACSI--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2341,7 +2803,9 @@
   {
     "sidc": "G*F*ACSR--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Undefined",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2352,7 +2816,9 @@
   {
     "sidc": "G*F*ACT---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2363,7 +2829,9 @@
   {
     "sidc": "G*F*ACVC--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Undefined",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2374,7 +2842,9 @@
   {
     "sidc": "G*F*ACVI--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2385,7 +2855,9 @@
   {
     "sidc": "G*F*ACVR--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Undefined",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2396,7 +2868,9 @@
   {
     "sidc": "G*F*ACZC--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Undefined",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2407,7 +2881,9 @@
   {
     "sidc": "G*F*ACZI--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2418,7 +2894,9 @@
   {
     "sidc": "G*F*ACZR--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Undefined",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2429,7 +2907,9 @@
   {
     "sidc": "G*F*AKBC--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Undefined",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2440,7 +2920,9 @@
   {
     "sidc": "G*F*AKBI--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2451,7 +2933,9 @@
   {
     "sidc": "G*F*AKBR--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Undefined",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2462,7 +2946,9 @@
   {
     "sidc": "G*F*AKPC--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Undefined",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2473,7 +2959,9 @@
   {
     "sidc": "G*F*AKPI--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2484,7 +2972,9 @@
   {
     "sidc": "G*F*AKPR--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Undefined",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2495,7 +2985,9 @@
   {
     "sidc": "G*F*AT----*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2506,7 +2998,9 @@
   {
     "sidc": "G*F*ATB---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2518,7 +3012,9 @@
   {
     "sidc": "G*F*ATC---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Undefined",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2530,7 +3026,9 @@
   {
     "sidc": "G*F*ATG---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2542,7 +3040,9 @@
   {
     "sidc": "G*F*ATR---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Undefined",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2554,7 +3054,9 @@
   {
     "sidc": "G*F*ATS---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2566,7 +3068,9 @@
   {
     "sidc": "G*F*AXC---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Undefined",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2577,7 +3081,9 @@
   {
     "sidc": "G*F*AXS---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Undefined",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2588,7 +3094,9 @@
   {
     "sidc": "G*F*AZCI--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2600,7 +3108,9 @@
   {
     "sidc": "G*F*AZCR--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Undefined",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2612,7 +3122,9 @@
   {
     "sidc": "G*F*AZFI--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2624,7 +3136,9 @@
   {
     "sidc": "G*F*AZFR--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Undefined",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2636,7 +3150,9 @@
   {
     "sidc": "G*F*AZII--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2648,7 +3164,9 @@
   {
     "sidc": "G*F*AZIR--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Undefined",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2660,7 +3178,9 @@
   {
     "sidc": "G*F*AZXI--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2672,7 +3192,9 @@
   {
     "sidc": "G*F*AZXR--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Undefined",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2684,7 +3206,9 @@
   {
     "sidc": "G*F*LCC---*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "LineString",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2695,7 +3219,9 @@
   {
     "sidc": "G*F*LCF---*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "LineString",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2706,7 +3232,9 @@
   {
     "sidc": "G*F*LCM---*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "LineString",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2717,7 +3245,9 @@
   {
     "sidc": "G*F*LCN---*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "LineString",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2728,7 +3258,9 @@
   {
     "sidc": "G*F*LCR---*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "LineString",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2739,7 +3271,9 @@
   {
     "sidc": "G*F*LT----*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "LineString",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2753,7 +3287,9 @@
   {
     "sidc": "G*F*LTF---*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "LineString",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2768,7 +3304,9 @@
   {
     "sidc": "G*F*LTS---*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "LineString",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2783,7 +3321,9 @@
   {
     "sidc": "G*F*PCB---*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2794,7 +3334,9 @@
   {
     "sidc": "G*F*PCF---*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2805,7 +3347,9 @@
   {
     "sidc": "G*F*PCH---*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2816,7 +3360,9 @@
   {
     "sidc": "G*F*PCL---*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2827,7 +3373,9 @@
   {
     "sidc": "G*F*PCR---*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2838,7 +3386,9 @@
   {
     "sidc": "G*F*PCS---*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2849,7 +3399,9 @@
   {
     "sidc": "G*F*PTN---*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2860,7 +3412,9 @@
   {
     "sidc": "G*F*PTS---*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "FIRE",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "FIRE SUPPORT",
@@ -2871,7 +3425,9 @@
   {
     "sidc": "G*G*AAF---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -2883,7 +3439,9 @@
   {
     "sidc": "G*G*AAH---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -2895,7 +3453,9 @@
   {
     "sidc": "G*G*AAM---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -2907,7 +3467,9 @@
   {
     "sidc": "G*G*AAMH--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -2920,7 +3482,9 @@
   {
     "sidc": "G*G*AAML--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -2933,7 +3497,9 @@
   {
     "sidc": "G*G*AAR---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -2945,7 +3511,9 @@
   {
     "sidc": "G*G*AAW---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -2957,7 +3525,9 @@
   {
     "sidc": "G*G*ALC---*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "GeometryCollection",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -2972,7 +3542,9 @@
   {
     "sidc": "G*G*ALL---*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "GeometryCollection",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -2987,7 +3559,9 @@
   {
     "sidc": "G*G*ALM---*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "GeometryCollection",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3002,7 +3576,9 @@
   {
     "sidc": "G*G*ALS---*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "GeometryCollection",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3017,7 +3593,9 @@
   {
     "sidc": "G*G*ALU---*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "GeometryCollection",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3032,7 +3610,9 @@
   {
     "sidc": "G*G*APC---*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3044,7 +3624,9 @@
   {
     "sidc": "G*G*APD---*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3056,7 +3638,9 @@
   {
     "sidc": "G*G*APP---*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3068,7 +3652,9 @@
   {
     "sidc": "G*G*APU---*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3080,7 +3666,9 @@
   {
     "sidc": "G*G*DAB---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3092,7 +3680,9 @@
   {
     "sidc": "G*G*DABP--*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3105,7 +3695,9 @@
   {
     "sidc": "G*G*DAE---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3117,7 +3709,9 @@
   {
     "sidc": "G*G*DLF---*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "LineString",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3129,7 +3723,9 @@
   {
     "sidc": "G*G*DLP---*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "MultiPoint",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3146,7 +3742,9 @@
   {
     "sidc": "G*G*DPO---*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3158,7 +3756,9 @@
   {
     "sidc": "G*G*DPOC--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3171,7 +3771,9 @@
   {
     "sidc": "G*G*DPOF--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3184,7 +3786,9 @@
   {
     "sidc": "G*G*DPON--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3197,7 +3801,9 @@
   {
     "sidc": "G*G*DPOR--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3210,7 +3816,9 @@
   {
     "sidc": "G*G*DPOS--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3223,7 +3831,9 @@
   {
     "sidc": "G*G*DPT---*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3235,7 +3845,9 @@
   {
     "sidc": "G*G*GAA---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3247,7 +3859,9 @@
   {
     "sidc": "G*G*GAD---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3259,7 +3873,9 @@
   {
     "sidc": "G*G*GAE---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3271,7 +3887,9 @@
   {
     "sidc": "G*G*GAF---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3283,7 +3901,9 @@
   {
     "sidc": "G*G*GAG---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3295,7 +3915,9 @@
   {
     "sidc": "G*G*GAL---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3307,7 +3929,9 @@
   {
     "sidc": "G*G*GAP---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3319,7 +3943,9 @@
   {
     "sidc": "G*G*GAS---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "MultiPoint",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3336,7 +3962,9 @@
   {
     "sidc": "G*G*GAX---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3348,7 +3976,9 @@
   {
     "sidc": "G*G*GAY---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3360,7 +3990,9 @@
   {
     "sidc": "G*G*GAZ---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3372,7 +4004,9 @@
   {
     "sidc": "G*G*GLB---*****",
     "class": "BL",
+    "scope": "CONTROL",
     "geometry": "LineString",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3384,7 +4018,9 @@
   {
     "sidc": "G*G*GLC---*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "LineString",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3396,7 +4032,9 @@
   {
     "sidc": "G*G*GLF---*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "LineString",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3408,7 +4046,9 @@
   {
     "sidc": "G*G*GLL---*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "LineString",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3420,7 +4060,9 @@
   {
     "sidc": "G*G*GLP---*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "LineString",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3432,7 +4074,9 @@
   {
     "sidc": "G*G*GPAA--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3445,7 +4089,9 @@
   {
     "sidc": "G*G*GPAB--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3458,7 +4104,9 @@
   {
     "sidc": "G*G*GPAC--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3471,7 +4119,9 @@
   {
     "sidc": "G*G*GPAD--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3484,7 +4134,9 @@
   {
     "sidc": "G*G*GPAE--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3497,7 +4149,9 @@
   {
     "sidc": "G*G*GPAF--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3510,7 +4164,9 @@
   {
     "sidc": "G*G*GPAG--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3523,7 +4179,9 @@
   {
     "sidc": "G*G*GPAH--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3536,7 +4194,9 @@
   {
     "sidc": "G*G*GPAI--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3549,7 +4209,9 @@
   {
     "sidc": "G*G*GPAJ--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3562,7 +4224,9 @@
   {
     "sidc": "G*G*GPAK--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3575,7 +4239,9 @@
   {
     "sidc": "G*G*GPAL--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3588,7 +4254,9 @@
   {
     "sidc": "G*G*GPAM--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3601,7 +4269,9 @@
   {
     "sidc": "G*G*GPAN--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3614,7 +4284,9 @@
   {
     "sidc": "G*G*GPAO--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3627,7 +4299,9 @@
   {
     "sidc": "G*G*GPAP--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3640,7 +4314,9 @@
   {
     "sidc": "G*G*GPAR--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3653,7 +4329,9 @@
   {
     "sidc": "G*G*GPAS--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3666,7 +4344,9 @@
   {
     "sidc": "G*G*GPAT--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3679,7 +4359,9 @@
   {
     "sidc": "G*G*GPAW--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3692,7 +4374,9 @@
   {
     "sidc": "G*G*GPB---*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3704,7 +4388,9 @@
   {
     "sidc": "G*G*GPBS--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3717,7 +4403,9 @@
   {
     "sidc": "G*G*GPBSA-*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3730,7 +4418,9 @@
   {
     "sidc": "G*G*GPBU--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3743,7 +4433,9 @@
   {
     "sidc": "G*G*GPBUA-*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3757,7 +4449,9 @@
   {
     "sidc": "G*G*GPBUM-*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3771,7 +4465,9 @@
   {
     "sidc": "G*G*GPBUS-*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3785,7 +4481,9 @@
   {
     "sidc": "G*G*GPC---*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3797,7 +4495,9 @@
   {
     "sidc": "G*G*GPCA--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3810,7 +4510,9 @@
   {
     "sidc": "G*G*GPCC--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3823,7 +4525,9 @@
   {
     "sidc": "G*G*GPCE--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3836,7 +4540,9 @@
   {
     "sidc": "G*G*GPCM--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3849,7 +4555,9 @@
   {
     "sidc": "G*G*GPCN--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3862,7 +4570,9 @@
   {
     "sidc": "G*G*GPCP--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3875,7 +4585,9 @@
   {
     "sidc": "G*G*GPCR--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3888,7 +4600,9 @@
   {
     "sidc": "G*G*GPCS--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3901,7 +4615,9 @@
   {
     "sidc": "G*G*GPCU--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3914,7 +4630,9 @@
   {
     "sidc": "G*G*GPCUA-*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3928,7 +4646,9 @@
   {
     "sidc": "G*G*GPCUM-*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3942,7 +4662,9 @@
   {
     "sidc": "G*G*GPCUR-*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3956,7 +4678,9 @@
   {
     "sidc": "G*G*GPCUS-*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3970,7 +4694,9 @@
   {
     "sidc": "G*G*GPF---*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3982,7 +4708,9 @@
   {
     "sidc": "G*G*GPH---*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -3994,7 +4722,9 @@
   {
     "sidc": "G*G*GPHA--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4007,7 +4737,9 @@
   {
     "sidc": "G*G*GPHQ--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4020,7 +4752,9 @@
   {
     "sidc": "G*G*GPHX--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4033,7 +4767,9 @@
   {
     "sidc": "G*G*GPHY--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4046,7 +4782,9 @@
   {
     "sidc": "G*G*GPO---*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4058,7 +4796,9 @@
   {
     "sidc": "G*G*GPOD--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4071,7 +4811,9 @@
   {
     "sidc": "G*G*GPOP--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4084,7 +4826,9 @@
   {
     "sidc": "G*G*GPOR--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4097,7 +4841,9 @@
   {
     "sidc": "G*G*GPOW--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4110,7 +4856,9 @@
   {
     "sidc": "G*G*GPOZ--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4123,7 +4871,9 @@
   {
     "sidc": "G*G*GPP---*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4134,7 +4884,9 @@
   {
     "sidc": "G*G*GPPA--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4146,7 +4898,9 @@
   {
     "sidc": "G*G*GPPC--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4158,7 +4912,9 @@
   {
     "sidc": "G*G*GPPD--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4170,7 +4926,9 @@
   {
     "sidc": "G*G*GPPE--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4182,7 +4940,9 @@
   {
     "sidc": "G*G*GPPK--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4194,7 +4954,9 @@
   {
     "sidc": "G*G*GPPL--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4206,7 +4968,9 @@
   {
     "sidc": "G*G*GPPO--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4218,7 +4982,9 @@
   {
     "sidc": "G*G*GPPP--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4230,7 +4996,9 @@
   {
     "sidc": "G*G*GPPR--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4242,7 +5010,9 @@
   {
     "sidc": "G*G*GPPS--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4254,7 +5024,9 @@
   {
     "sidc": "G*G*GPPW--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4266,7 +5038,9 @@
   {
     "sidc": "G*G*GPR---*****",
     "class": "P",
-    "geometry": "point",
+    "scope": "CONTROL",
+    "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4278,7 +5052,9 @@
   {
     "sidc": "G*G*GPRC--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4291,7 +5067,9 @@
   {
     "sidc": "G*G*GPRD--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4304,7 +5082,9 @@
   {
     "sidc": "G*G*GPRI--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4317,7 +5097,9 @@
   {
     "sidc": "G*G*GPRM--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4330,7 +5112,9 @@
   {
     "sidc": "G*G*GPRN--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4342,7 +5126,9 @@
   {
     "sidc": "G*G*GPRP--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4355,7 +5141,9 @@
   {
     "sidc": "G*G*GPRS--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4368,7 +5156,9 @@
   {
     "sidc": "G*G*GPRW--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4381,7 +5171,9 @@
   {
     "sidc": "G*G*GPUS--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4394,7 +5186,9 @@
   {
     "sidc": "G*G*GPUSA-*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4407,7 +5201,9 @@
   {
     "sidc": "G*G*GPUSC-*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4420,7 +5216,9 @@
   {
     "sidc": "G*G*GPUSD-*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4434,7 +5232,9 @@
   {
     "sidc": "G*G*GPUUB-*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4448,7 +5248,9 @@
   {
     "sidc": "G*G*GPUUD-*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4462,7 +5264,9 @@
   {
     "sidc": "G*G*GPUUL-*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4476,7 +5280,9 @@
   {
     "sidc": "G*G*GPUUS-*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4490,7 +5296,9 @@
   {
     "sidc": "G*G*GPUY--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4503,7 +5311,9 @@
   {
     "sidc": "G*G*GPUYA-*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4517,7 +5327,9 @@
   {
     "sidc": "G*G*GPUYB-*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4531,7 +5343,9 @@
   {
     "sidc": "G*G*GPUYC-*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4544,7 +5358,9 @@
   {
     "sidc": "G*G*GPUYD-*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4558,7 +5374,9 @@
   {
     "sidc": "G*G*GPUYK-*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4572,7 +5390,9 @@
   {
     "sidc": "G*G*GPUYL-*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4586,7 +5406,9 @@
   {
     "sidc": "G*G*GPUYP-*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4600,7 +5422,9 @@
   {
     "sidc": "G*G*GPUYR-*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4614,7 +5438,9 @@
   {
     "sidc": "G*G*GPUYS-*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4627,7 +5453,9 @@
   {
     "sidc": "G*G*GPUYT-*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4641,7 +5469,9 @@
   {
     "sidc": "G*G*GPUYV-*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4655,7 +5485,9 @@
   {
     "sidc": "G*G*GPUYX-*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4668,7 +5500,9 @@
   {
     "sidc": "G*G*GPWA--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4681,7 +5515,9 @@
   {
     "sidc": "G*G*GPWD--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4694,7 +5530,9 @@
   {
     "sidc": "G*G*GPWE--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4707,7 +5545,9 @@
   {
     "sidc": "G*G*GPWG--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4720,7 +5560,9 @@
   {
     "sidc": "G*G*GPWI--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4733,7 +5575,9 @@
   {
     "sidc": "G*G*GPWM--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4746,7 +5590,9 @@
   {
     "sidc": "G*G*GPWP--*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4759,7 +5605,9 @@
   {
     "sidc": "G*G*OAA---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4771,7 +5619,9 @@
   {
     "sidc": "G*G*OAF---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "GeometryCollection",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4787,7 +5637,9 @@
   {
     "sidc": "G*G*OAK---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4799,7 +5651,9 @@
   {
     "sidc": "G*G*OAO---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4811,7 +5665,9 @@
   {
     "sidc": "G*G*OAP---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4823,7 +5679,9 @@
   {
     "sidc": "G*G*OAS---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "MultiPoint",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4840,7 +5698,9 @@
   {
     "sidc": "G*G*OLAA--*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "GeometryCollection",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4856,7 +5716,9 @@
   {
     "sidc": "G*G*OLAGM-*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "GeometryCollection",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4865,12 +5727,17 @@
       "AXIS OF ADVANCE",
       "GROUND",
       "MAIN ATTACK"
-    ]
+    ],
+    "parameters": {
+      "layout": "corridor"
+    }
   },
   {
     "sidc": "G*G*OLAGS-*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "GeometryCollection",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4879,12 +5746,17 @@
       "AXIS OF ADVANCE",
       "GROUND",
       "SUPPORTING ATTACK"
-    ]
+    ],
+    "parameters": {
+      "layout": "corridor"
+    }
   },
   {
     "sidc": "G*G*OLAR--*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "GeometryCollection",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4900,7 +5772,9 @@
   {
     "sidc": "G*G*OLAV--*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "GeometryCollection",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4916,7 +5790,9 @@
   {
     "sidc": "G*G*OLC---*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "LineString",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4928,7 +5804,9 @@
   {
     "sidc": "G*G*OLF---*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "LineString",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4940,7 +5818,9 @@
   {
     "sidc": "G*G*OLI---*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "GeometryCollection",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4956,7 +5836,9 @@
   {
     "sidc": "G*G*OLKA--*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "LineString",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4971,7 +5853,9 @@
   {
     "sidc": "G*G*OLKGM-*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "LineString",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4984,7 +5868,9 @@
   {
     "sidc": "G*G*OLKGS-*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "LineString",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -4997,7 +5883,9 @@
   {
     "sidc": "G*G*OLL---*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "LineString",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -5009,7 +5897,9 @@
   {
     "sidc": "G*G*OLP---*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "LineString",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -5021,7 +5911,9 @@
   {
     "sidc": "G*G*OLT---*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "LineString",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -5033,7 +5925,9 @@
   {
     "sidc": "G*G*OPP---*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -5044,7 +5938,9 @@
   },
   {
     "sidc": "G*G*PA----*****",
+    "scope": "CONTROL",
     "geometry": "GeometryCollection",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -5058,7 +5954,9 @@
   {
     "sidc": "G*G*PC----*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -5068,7 +5966,9 @@
   },
   {
     "sidc": "G*G*PD----*****",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -5078,7 +5978,9 @@
   {
     "sidc": "G*G*PF----*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "LineString",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -5092,7 +5994,9 @@
   {
     "sidc": "G*G*PM----*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -5102,7 +6006,9 @@
   },
   {
     "sidc": "G*G*PN----*****",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -5113,7 +6019,9 @@
   {
     "sidc": "G*G*PY----*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -5124,7 +6032,9 @@
   {
     "sidc": "G*G*SAA---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -5136,7 +6046,9 @@
   {
     "sidc": "G*G*SAE---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -5148,7 +6060,9 @@
   {
     "sidc": "G*G*SAN---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -5159,7 +6073,9 @@
   {
     "sidc": "G*G*SAO---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -5170,7 +6086,9 @@
   {
     "sidc": "G*G*SAT---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -5181,7 +6099,9 @@
   {
     "sidc": "G*G*SLA---*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "GeometryCollection",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -5197,7 +6117,9 @@
   {
     "sidc": "G*G*SLB---*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "Undefined",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -5209,7 +6131,9 @@
   {
     "sidc": "G*G*SLH---*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "LineString",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -5220,7 +6144,9 @@
   {
     "sidc": "G*G*SLR---*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "LineString",
+    "dimension": "C2",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMMAND AND CONTROL AND GENERAL MANEUVER",
@@ -5230,6 +6156,7 @@
   },
   {
     "sidc": "G*M*BCA---*****",
+    "scope": "CONTROL",
     "geometry": "Point",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5241,6 +6168,7 @@
   },
   {
     "sidc": "G*M*BCB---*****",
+    "scope": "CONTROL",
     "geometry": "GeometryCollection",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5256,6 +6184,7 @@
   },
   {
     "sidc": "G*M*BCD---*****",
+    "scope": "CONTROL",
     "geometry": "GeometryCollection",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5271,6 +6200,7 @@
   },
   {
     "sidc": "G*M*BCE---*****",
+    "scope": "CONTROL",
     "geometry": "GeometryCollection",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5286,6 +6216,7 @@
   },
   {
     "sidc": "G*M*BCF---*****",
+    "scope": "CONTROL",
     "geometry": "LineString",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5300,6 +6231,7 @@
   },
   {
     "sidc": "G*M*BCL---*****",
+    "scope": "CONTROL",
     "geometry": "LineString",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5314,6 +6246,7 @@
   },
   {
     "sidc": "G*M*BCP---*****",
+    "scope": "CONTROL",
     "geometry": "Point",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5325,6 +6258,7 @@
   },
   {
     "sidc": "G*M*BCR---*****",
+    "scope": "CONTROL",
     "geometry": "LineString",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5339,6 +6273,7 @@
   },
   {
     "sidc": "G*M*BDD---*****",
+    "scope": "CONTROL",
     "geometry": "GeometryCollection",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5353,6 +6288,7 @@
   },
   {
     "sidc": "G*M*BDE---*****",
+    "scope": "CONTROL",
     "geometry": "GeometryCollection",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5367,6 +6303,7 @@
   },
   {
     "sidc": "G*M*BDI---*****",
+    "scope": "CONTROL",
     "geometry": "GeometryCollection",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5382,6 +6319,7 @@
   {
     "sidc": "G*M*NB----*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5393,6 +6331,7 @@
   {
     "sidc": "G*M*NC----*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5403,6 +6342,7 @@
   },
   {
     "sidc": "G*M*NDA---*****",
+    "scope": "CONTROL",
     "geometry": "Point",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5414,6 +6354,7 @@
   },
   {
     "sidc": "G*M*NDB---*****",
+    "scope": "CONTROL",
     "geometry": "Point",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5425,6 +6366,7 @@
   },
   {
     "sidc": "G*M*NDD---*****",
+    "scope": "CONTROL",
     "geometry": "Point",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5436,6 +6378,7 @@
   },
   {
     "sidc": "G*M*NDE---*****",
+    "scope": "CONTROL",
     "geometry": "Point",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5447,6 +6390,7 @@
   },
   {
     "sidc": "G*M*NDO---*****",
+    "scope": "CONTROL",
     "geometry": "Point",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5458,6 +6402,7 @@
   },
   {
     "sidc": "G*M*NDP---*****",
+    "scope": "CONTROL",
     "geometry": "Point",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5469,6 +6414,7 @@
   },
   {
     "sidc": "G*M*NDT---*****",
+    "scope": "CONTROL",
     "geometry": "Point",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5480,6 +6426,7 @@
   },
   {
     "sidc": "G*M*NEB---*****",
+    "scope": "CONTROL",
     "geometry": "Point",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5491,6 +6438,7 @@
   },
   {
     "sidc": "G*M*NEC---*****",
+    "scope": "CONTROL",
     "geometry": "Point",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5502,6 +6450,7 @@
   },
   {
     "sidc": "G*M*NF----*****",
+    "scope": "CONTROL",
     "geometry": "Point",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5513,6 +6462,7 @@
   {
     "sidc": "G*M*NL----*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5522,8 +6472,20 @@
     ]
   },
   {
+    "sidc": "G*M*NM----*****",
+    "scope": "CONTROL",
+    "geometry": "point",
+    "hierarchy": [
+      "TACTICAL GRAPHICS",
+      "MOBILITY / SURVIVABILITY",
+      "CHEMICAL, BIOLOGICAL, RADIOLOGICAL, AND NUCLEAR",
+      "MINIMUM SAFE DISTANCE ZONES"
+    ]
+  },
+  {
     "sidc": "G*M*NR----*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5534,6 +6496,7 @@
   },
   {
     "sidc": "G*M*NZ----*****",
+    "scope": "CONTROL",
     "geometry": "Point",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5544,6 +6507,7 @@
   },
   {
     "sidc": "G*M*OADC--*****",
+    "scope": "CONTROL",
     "geometry": "LineString",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5554,6 +6518,7 @@
   },
   {
     "sidc": "G*M*OADU--*****",
+    "scope": "CONTROL",
     "geometry": "LineString",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5564,6 +6529,7 @@
   },
   {
     "sidc": "G*M*OAOF--*****",
+    "scope": "CONTROL",
     "geometry": "Point",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5574,6 +6540,7 @@
   },
   {
     "sidc": "G*M*OAOM--*****",
+    "scope": "CONTROL",
     "geometry": "Point",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5584,6 +6551,7 @@
   },
   {
     "sidc": "G*M*OAOP--*****",
+    "scope": "CONTROL",
     "geometry": "Point",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5594,6 +6562,7 @@
   },
   {
     "sidc": "G*M*OAR---*****",
+    "scope": "CONTROL",
     "geometry": "LineString",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5604,6 +6573,7 @@
   },
   {
     "sidc": "G*M*OAW---*****",
+    "scope": "CONTROL",
     "geometry": "LineString",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5614,6 +6584,7 @@
   },
   {
     "sidc": "G*M*OB----*****",
+    "scope": "CONTROL",
     "geometry": "Point",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5624,6 +6595,7 @@
   },
   {
     "sidc": "G*M*OEB---*****",
+    "scope": "CONTROL",
     "geometry": "GeometryCollection",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5639,6 +6611,7 @@
   },
   {
     "sidc": "G*M*OED---*****",
+    "scope": "CONTROL",
     "geometry": "GeometryCollection",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5654,6 +6627,7 @@
   },
   {
     "sidc": "G*M*OEF---*****",
+    "scope": "CONTROL",
     "geometry": "LineString",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5668,6 +6642,7 @@
   },
   {
     "sidc": "G*M*OET---*****",
+    "scope": "CONTROL",
     "geometry": "MultiPoint",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5684,6 +6659,7 @@
   {
     "sidc": "G*M*OFA---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5696,6 +6672,7 @@
   {
     "sidc": "G*M*OFD---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5707,6 +6684,7 @@
   },
   {
     "sidc": "G*M*OFG---*****",
+    "scope": "CONTROL",
     "geometry": "GeometryCollection",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5722,6 +6700,7 @@
   },
   {
     "sidc": "G*M*OFS---*****",
+    "scope": "CONTROL",
     "geometry": "Point",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5733,6 +6712,7 @@
   },
   {
     "sidc": "G*M*OGB---*****",
+    "scope": "CONTROL",
     "geometry": "Polygon",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5745,6 +6725,7 @@
   {
     "sidc": "G*M*OGF---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5756,6 +6737,7 @@
   },
   {
     "sidc": "G*M*OGL---*****",
+    "scope": "CONTROL",
     "geometry": "LineString",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5768,6 +6750,7 @@
   {
     "sidc": "G*M*OGR---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5780,6 +6763,7 @@
   {
     "sidc": "G*M*OGZ---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5791,6 +6775,7 @@
   },
   {
     "sidc": "G*M*OHO---*****",
+    "scope": "CONTROL",
     "geometry": "LineString",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5800,6 +6785,7 @@
   },
   {
     "sidc": "G*M*OHTH--*****",
+    "scope": "CONTROL",
     "geometry": "Point",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5809,6 +6795,7 @@
   },
   {
     "sidc": "G*M*OHTL--*****",
+    "scope": "CONTROL",
     "geometry": "Point",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5818,6 +6805,7 @@
   },
   {
     "sidc": "G*M*OMC---*****",
+    "scope": "CONTROL",
     "geometry": "LineString",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5829,6 +6817,7 @@
   },
   {
     "sidc": "G*M*OMD---*****",
+    "scope": "CONTROL",
     "geometry": "Point",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5840,6 +6829,7 @@
   },
   {
     "sidc": "G*M*OME---*****",
+    "scope": "CONTROL",
     "geometry": "Point",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5851,6 +6841,7 @@
   },
   {
     "sidc": "G*M*OMP---*****",
+    "scope": "CONTROL",
     "geometry": "Point",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5861,6 +6852,7 @@
   },
   {
     "sidc": "G*M*OMT---*****",
+    "scope": "CONTROL",
     "geometry": "Point",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5872,6 +6864,7 @@
   },
   {
     "sidc": "G*M*OMU---*****",
+    "scope": "CONTROL",
     "geometry": "Point",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5883,6 +6876,7 @@
   },
   {
     "sidc": "G*M*OMW---*****",
+    "scope": "CONTROL",
     "geometry": "Point",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5893,6 +6887,7 @@
   },
   {
     "sidc": "G*M*ORA---*****",
+    "scope": "CONTROL",
     "geometry": "GeometryCollection",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5908,6 +6903,7 @@
   },
   {
     "sidc": "G*M*ORC---*****",
+    "scope": "CONTROL",
     "geometry": "GeometryCollection",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5923,6 +6919,7 @@
   },
   {
     "sidc": "G*M*ORP---*****",
+    "scope": "CONTROL",
     "geometry": "GeometryCollection",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5938,6 +6935,7 @@
   },
   {
     "sidc": "G*M*ORS---*****",
+    "scope": "CONTROL",
     "geometry": "GeometryCollection",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5953,6 +6951,7 @@
   },
   {
     "sidc": "G*M*OS----*****",
+    "scope": "CONTROL",
     "geometry": "LineString",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5963,6 +6962,7 @@
   },
   {
     "sidc": "G*M*OT----*****",
+    "scope": "CONTROL",
     "geometry": "LineString",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5974,6 +6974,7 @@
   {
     "sidc": "G*M*OU----*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5984,6 +6985,7 @@
   },
   {
     "sidc": "G*M*OWA---*****",
+    "scope": "CONTROL",
     "geometry": "LineString",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -5995,6 +6997,7 @@
   },
   {
     "sidc": "G*M*OWCD--*****",
+    "scope": "CONTROL",
     "geometry": "LineString",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -6006,6 +7009,7 @@
   },
   {
     "sidc": "G*M*OWCS--*****",
+    "scope": "CONTROL",
     "geometry": "LineString",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -6017,6 +7021,7 @@
   },
   {
     "sidc": "G*M*OWCT--*****",
+    "scope": "CONTROL",
     "geometry": "LineString",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -6028,6 +7033,7 @@
   },
   {
     "sidc": "G*M*OWD---*****",
+    "scope": "CONTROL",
     "geometry": "LineString",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -6039,6 +7045,7 @@
   },
   {
     "sidc": "G*M*OWH---*****",
+    "scope": "CONTROL",
     "geometry": "LineString",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -6050,6 +7057,7 @@
   },
   {
     "sidc": "G*M*OWL---*****",
+    "scope": "CONTROL",
     "geometry": "LineString",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -6061,6 +7069,7 @@
   },
   {
     "sidc": "G*M*OWS---*****",
+    "scope": "CONTROL",
     "geometry": "LineString",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -6072,6 +7081,7 @@
   },
   {
     "sidc": "G*M*OWU---*****",
+    "scope": "CONTROL",
     "geometry": "LineString",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -6083,6 +7093,7 @@
   },
   {
     "sidc": "G*M*SE----*****",
+    "scope": "CONTROL",
     "geometry": "Point",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -6093,6 +7104,7 @@
   },
   {
     "sidc": "G*M*SF----*****",
+    "scope": "CONTROL",
     "geometry": "Point",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -6103,6 +7115,7 @@
   },
   {
     "sidc": "G*M*SL----*****",
+    "scope": "CONTROL",
     "geometry": "LineString",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -6114,6 +7127,7 @@
   {
     "sidc": "G*M*SP----*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -6124,6 +7138,7 @@
   },
   {
     "sidc": "G*M*SS----*****",
+    "scope": "CONTROL",
     "geometry": "Point",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -6134,6 +7149,7 @@
   },
   {
     "sidc": "G*M*SU----*****",
+    "scope": "CONTROL",
     "geometry": "Point",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -6144,6 +7160,7 @@
   },
   {
     "sidc": "G*M*SW----*****",
+    "scope": "CONTROL",
     "geometry": "LineString",
     "hierarchy": [
       "TACTICAL GRAPHICS",
@@ -6157,7 +7174,9 @@
   },
   {
     "sidc": "G*O*B-----*****",
+    "scope": "CONTROL",
     "geometry": "LineString",
+    "dimension": "MARITIME",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "OTHER",
@@ -6169,7 +7188,9 @@
   },
   {
     "sidc": "G*O*BA----*****",
+    "scope": "CONTROL",
     "geometry": "LineString",
+    "dimension": "MARITIME",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "OTHER",
@@ -6182,7 +7203,9 @@
   },
   {
     "sidc": "G*O*BE----*****",
+    "scope": "CONTROL",
     "geometry": "LineString",
+    "dimension": "MARITIME",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "OTHER",
@@ -6195,7 +7218,9 @@
   },
   {
     "sidc": "G*O*BO----*****",
+    "scope": "CONTROL",
     "geometry": "LineString",
+    "dimension": "MARITIME",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "OTHER",
@@ -6208,7 +7233,9 @@
   },
   {
     "sidc": "G*O*BT----*****",
+    "scope": "CONTROL",
     "geometry": "LineString",
+    "dimension": "MARITIME",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "OTHER",
@@ -6221,7 +7248,9 @@
   },
   {
     "sidc": "G*O*ED----*****",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "MARITIME",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "OTHER",
@@ -6231,7 +7260,9 @@
   },
   {
     "sidc": "G*O*EP----*****",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "MARITIME",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "OTHER",
@@ -6241,7 +7272,9 @@
   },
   {
     "sidc": "G*O*EV----*****",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "MARITIME",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "OTHER",
@@ -6251,7 +7284,9 @@
   },
   {
     "sidc": "G*O*FA----*****",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "MARITIME",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "OTHER",
@@ -6261,7 +7296,9 @@
   },
   {
     "sidc": "G*O*FE----*****",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "MARITIME",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "OTHER",
@@ -6271,7 +7308,9 @@
   },
   {
     "sidc": "G*O*FO----*****",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "MARITIME",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "OTHER",
@@ -6281,7 +7320,9 @@
   },
   {
     "sidc": "G*O*HI----*****",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "MARITIME",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "OTHER",
@@ -6291,7 +7332,9 @@
   },
   {
     "sidc": "G*O*HM----*****",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "MARITIME",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "OTHER",
@@ -6301,7 +7344,9 @@
   },
   {
     "sidc": "G*O*HN----*****",
+    "scope": "CONTROL",
     "geometry": "LineString",
+    "dimension": "MARITIME",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "OTHER",
@@ -6314,7 +7359,9 @@
   },
   {
     "sidc": "G*O*HO----*****",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "MARITIME",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "OTHER",
@@ -6324,7 +7371,9 @@
   },
   {
     "sidc": "G*O*SB----*****",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "MARITIME",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "OTHER",
@@ -6334,7 +7383,9 @@
   },
   {
     "sidc": "G*O*SBM---*****",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "MARITIME",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "OTHER",
@@ -6345,7 +7396,9 @@
   },
   {
     "sidc": "G*O*SBN---*****",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "MARITIME",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "OTHER",
@@ -6356,7 +7409,9 @@
   },
   {
     "sidc": "G*O*SBW---*****",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "MARITIME",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "OTHER",
@@ -6367,7 +7422,9 @@
   },
   {
     "sidc": "G*O*SBX---*****",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "MARITIME",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "OTHER",
@@ -6378,7 +7435,9 @@
   },
   {
     "sidc": "G*O*SM----*****",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "MARITIME",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "OTHER",
@@ -6388,7 +7447,9 @@
   },
   {
     "sidc": "G*O*SS----*****",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "MARITIME",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "OTHER",
@@ -6399,7 +7460,9 @@
   {
     "sidc": "G*S*AD----*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "CSS",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMBAT SERVICE SUPPORT",
@@ -6409,7 +7472,9 @@
   {
     "sidc": "G*S*AE----*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "CSS",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMBAT SERVICE SUPPORT",
@@ -6419,7 +7484,9 @@
   {
     "sidc": "G*S*AH----*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "CSS",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMBAT SERVICE SUPPORT",
@@ -6429,7 +7496,9 @@
   {
     "sidc": "G*S*AR----*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "CSS",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMBAT SERVICE SUPPORT",
@@ -6439,7 +7508,9 @@
   {
     "sidc": "G*S*ASB---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "CSS",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMBAT SERVICE SUPPORT",
@@ -6450,7 +7521,9 @@
   {
     "sidc": "G*S*ASD---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "CSS",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMBAT SERVICE SUPPORT",
@@ -6461,7 +7534,9 @@
   {
     "sidc": "G*S*ASR---*****",
     "class": "A",
+    "scope": "CONTROL",
     "geometry": "Polygon",
+    "dimension": "CSS",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMBAT SERVICE SUPPORT",
@@ -6472,7 +7547,9 @@
   {
     "sidc": "G*S*LCH---*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "LineString",
+    "dimension": "CSS",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMBAT SERVICE SUPPORT",
@@ -6487,7 +7564,9 @@
   {
     "sidc": "G*S*LCM---*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "LineString",
+    "dimension": "CSS",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMBAT SERVICE SUPPORT",
@@ -6502,7 +7581,9 @@
   {
     "sidc": "G*S*LRA---*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "LineString",
+    "dimension": "CSS",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMBAT SERVICE SUPPORT",
@@ -6514,7 +7595,9 @@
   {
     "sidc": "G*S*LRM---*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "LineString",
+    "dimension": "CSS",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMBAT SERVICE SUPPORT",
@@ -6526,7 +7609,9 @@
   {
     "sidc": "G*S*LRO---*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "LineString",
+    "dimension": "CSS",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMBAT SERVICE SUPPORT",
@@ -6538,7 +7623,9 @@
   {
     "sidc": "G*S*LRT---*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "LineString",
+    "dimension": "CSS",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMBAT SERVICE SUPPORT",
@@ -6550,7 +7637,9 @@
   {
     "sidc": "G*S*LRW---*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "LineString",
+    "dimension": "CSS",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMBAT SERVICE SUPPORT",
@@ -6562,7 +7651,9 @@
   {
     "sidc": "G*S*PAS---*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "CSS",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMBAT SERVICE SUPPORT",
@@ -6573,7 +7664,9 @@
   {
     "sidc": "G*S*PAT---*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "CSS",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMBAT SERVICE SUPPORT",
@@ -6584,7 +7677,9 @@
   {
     "sidc": "G*S*PC----*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "CSS",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMBAT SERVICE SUPPORT",
@@ -6595,7 +7690,9 @@
   {
     "sidc": "G*S*PD----*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "CSS",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMBAT SERVICE SUPPORT",
@@ -6606,7 +7703,9 @@
   {
     "sidc": "G*S*PE----*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "CSS",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMBAT SERVICE SUPPORT",
@@ -6617,7 +7716,9 @@
   {
     "sidc": "G*S*PI----*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "CSS",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMBAT SERVICE SUPPORT",
@@ -6628,7 +7729,9 @@
   {
     "sidc": "G*S*PL----*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "CSS",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMBAT SERVICE SUPPORT",
@@ -6639,7 +7742,9 @@
   {
     "sidc": "G*S*PM----*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "CSS",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMBAT SERVICE SUPPORT",
@@ -6650,7 +7755,9 @@
   {
     "sidc": "G*S*PN----*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "CSS",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMBAT SERVICE SUPPORT",
@@ -6661,7 +7768,9 @@
   {
     "sidc": "G*S*PO----*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "CSS",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMBAT SERVICE SUPPORT",
@@ -6672,7 +7781,9 @@
   {
     "sidc": "G*S*PR----*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "CSS",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMBAT SERVICE SUPPORT",
@@ -6683,7 +7794,9 @@
   {
     "sidc": "G*S*PSA---*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "CSS",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMBAT SERVICE SUPPORT",
@@ -6694,7 +7807,9 @@
   {
     "sidc": "G*S*PSB---*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "CSS",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMBAT SERVICE SUPPORT",
@@ -6705,7 +7820,9 @@
   {
     "sidc": "G*S*PSC---*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "CSS",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMBAT SERVICE SUPPORT",
@@ -6716,7 +7833,9 @@
   {
     "sidc": "G*S*PSD---*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "CSS",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMBAT SERVICE SUPPORT",
@@ -6727,7 +7846,9 @@
   {
     "sidc": "G*S*PSE---*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "CSS",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMBAT SERVICE SUPPORT",
@@ -6738,7 +7859,9 @@
   {
     "sidc": "G*S*PSF---*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "CSS",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMBAT SERVICE SUPPORT",
@@ -6749,7 +7872,9 @@
   {
     "sidc": "G*S*PSG---*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "CSS",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMBAT SERVICE SUPPORT",
@@ -6760,7 +7885,9 @@
   {
     "sidc": "G*S*PSH---*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "CSS",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMBAT SERVICE SUPPORT",
@@ -6771,7 +7898,9 @@
   {
     "sidc": "G*S*PSI---*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "CSS",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMBAT SERVICE SUPPORT",
@@ -6782,7 +7911,9 @@
   {
     "sidc": "G*S*PSJ---*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "CSS",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMBAT SERVICE SUPPORT",
@@ -6793,7 +7924,9 @@
   {
     "sidc": "G*S*PSZ---*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "CSS",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMBAT SERVICE SUPPORT",
@@ -6804,7 +7937,9 @@
   {
     "sidc": "G*S*PT----*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "CSS",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMBAT SERVICE SUPPORT",
@@ -6815,7 +7950,9 @@
   {
     "sidc": "G*S*PU----*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "CSS",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMBAT SERVICE SUPPORT",
@@ -6826,7 +7963,9 @@
   {
     "sidc": "G*S*PX----*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "CSS",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMBAT SERVICE SUPPORT",
@@ -6837,7 +7976,9 @@
   {
     "sidc": "G*S*PY----*****",
     "class": "P",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "CSS",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "COMBAT SERVICE SUPPORT",
@@ -6848,7 +7989,9 @@
   {
     "sidc": "G*T*A-----*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "LineString",
+    "dimension": "TASK",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "TASKS",
@@ -6861,7 +8004,9 @@
   {
     "sidc": "G*T*AS----*****",
     "class": "L",
+    "scope": "CONTROL",
     "geometry": "LineString",
+    "dimension": "TASK",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "TASKS",
@@ -6874,7 +8019,9 @@
   },
   {
     "sidc": "G*T*B-----*****",
+    "scope": "CONTROL",
     "geometry": "GeometryCollection",
+    "dimension": "TASK",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "TASKS",
@@ -6887,7 +8034,9 @@
   },
   {
     "sidc": "G*T*C-----*****",
+    "scope": "CONTROL",
     "geometry": "GeometryCollection",
+    "dimension": "TASK",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "TASKS",
@@ -6900,7 +8049,9 @@
   },
   {
     "sidc": "G*T*D-----*****",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "TASK",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "TASKS",
@@ -6909,7 +8060,9 @@
   },
   {
     "sidc": "G*T*E-----*****",
+    "scope": "CONTROL",
     "geometry": "MultiPoint",
+    "dimension": "TASK",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "TASKS",
@@ -6924,7 +8077,9 @@
   },
   {
     "sidc": "G*T*F-----*****",
+    "scope": "CONTROL",
     "geometry": "LineString",
+    "dimension": "TASK",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "TASKS",
@@ -6936,7 +8091,9 @@
   },
   {
     "sidc": "G*T*H-----*****",
+    "scope": "CONTROL",
     "geometry": "GeometryCollection",
+    "dimension": "TASK",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "TASKS",
@@ -6949,7 +8106,9 @@
   },
   {
     "sidc": "G*T*I-----*****",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "TASK",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "TASKS",
@@ -6958,7 +8117,9 @@
   },
   {
     "sidc": "G*T*J-----*****",
+    "scope": "CONTROL",
     "geometry": "GeometryCollection",
+    "dimension": "TASK",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "TASKS",
@@ -6971,7 +8132,9 @@
   },
   {
     "sidc": "G*T*K-----*****",
+    "scope": "CONTROL",
     "geometry": "GeometryCollection",
+    "dimension": "TASK",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "TASKS",
@@ -6983,7 +8146,9 @@
   },
   {
     "sidc": "G*T*KF----*****",
+    "scope": "CONTROL",
     "geometry": "GeometryCollection",
+    "dimension": "TASK",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "TASKS",
@@ -6996,7 +8161,9 @@
   },
   {
     "sidc": "G*T*L-----*****",
+    "scope": "CONTROL",
     "geometry": "GeometryCollection",
+    "dimension": "TASK",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "TASKS",
@@ -7008,7 +8175,9 @@
   },
   {
     "sidc": "G*T*M-----*****",
+    "scope": "CONTROL",
     "geometry": "GeometryCollection",
+    "dimension": "TASK",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "TASKS",
@@ -7020,7 +8189,9 @@
   },
   {
     "sidc": "G*T*N-----*****",
+    "scope": "CONTROL",
     "geometry": "Point",
+    "dimension": "TASK",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "TASKS",
@@ -7029,7 +8200,9 @@
   },
   {
     "sidc": "G*T*O-----*****",
+    "scope": "CONTROL",
     "geometry": "MultiPoint",
+    "dimension": "TASK",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "TASKS",
@@ -7044,7 +8217,9 @@
   },
   {
     "sidc": "G*T*P-----*****",
+    "scope": "CONTROL",
     "geometry": "GeometryCollection",
+    "dimension": "TASK",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "TASKS",
@@ -7057,7 +8232,9 @@
   },
   {
     "sidc": "G*T*Q-----*****",
+    "scope": "CONTROL",
     "geometry": "MultiPoint",
+    "dimension": "TASK",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "TASKS",
@@ -7072,7 +8249,9 @@
   },
   {
     "sidc": "G*T*R-----*****",
+    "scope": "CONTROL",
     "geometry": "GeometryCollection",
+    "dimension": "TASK",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "TASKS",
@@ -7084,7 +8263,9 @@
   },
   {
     "sidc": "G*T*S-----*****",
+    "scope": "CONTROL",
     "geometry": "MultiPoint",
+    "dimension": "TASK",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "TASKS",
@@ -7099,7 +8280,9 @@
   },
   {
     "sidc": "G*T*T-----*****",
+    "scope": "CONTROL",
     "geometry": "GeometryCollection",
+    "dimension": "TASK",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "TASKS",
@@ -7112,7 +8295,9 @@
   },
   {
     "sidc": "G*T*UC----*****",
+    "scope": "CONTROL",
     "geometry": "MultiPoint",
+    "dimension": "TASK",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "TASKS",
@@ -7127,7 +8312,9 @@
   },
   {
     "sidc": "G*T*UG----*****",
+    "scope": "CONTROL",
     "geometry": "MultiPoint",
+    "dimension": "TASK",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "TASKS",
@@ -7142,7 +8329,9 @@
   },
   {
     "sidc": "G*T*US----*****",
+    "scope": "CONTROL",
     "geometry": "MultiPoint",
+    "dimension": "TASK",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "TASKS",
@@ -7157,7 +8346,9 @@
   },
   {
     "sidc": "G*T*W-----*****",
+    "scope": "CONTROL",
     "geometry": "GeometryCollection",
+    "dimension": "TASK",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "TASKS",
@@ -7169,7 +8360,9 @@
   },
   {
     "sidc": "G*T*WP----*****",
+    "scope": "CONTROL",
     "geometry": "GeometryCollection",
+    "dimension": "TASK",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "TASKS",
@@ -7181,7 +8374,9 @@
   },
   {
     "sidc": "G*T*X-----*****",
+    "scope": "CONTROL",
     "geometry": "GeometryCollection",
+    "dimension": "TASK",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "TASKS",
@@ -7194,7 +8389,9 @@
   },
   {
     "sidc": "G*T*Y-----*****",
+    "scope": "CONTROL",
     "geometry": "GeometryCollection",
+    "dimension": "TASK",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "TASKS",
@@ -7207,7 +8404,9 @@
   },
   {
     "sidc": "G*T*Z-----*****",
+    "scope": "CONTROL",
     "geometry": "MultiPoint",
+    "dimension": "TASK",
     "hierarchy": [
       "TACTICAL GRAPHICS",
       "TASKS",
@@ -7221,7 +8420,9 @@
   {
     "sidc": "I*A*SCC-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "AIR TRACK",
@@ -7233,7 +8434,9 @@
   {
     "sidc": "I*A*SCO-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "AIR TRACK",
@@ -7245,7 +8448,9 @@
   {
     "sidc": "I*A*SCP-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "AIR TRACK",
@@ -7257,7 +8462,9 @@
   {
     "sidc": "I*A*SCS-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "AIR TRACK",
@@ -7269,7 +8476,9 @@
   {
     "sidc": "I*A*SRAI----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "AIR TRACK",
@@ -7281,7 +8490,9 @@
   {
     "sidc": "I*A*SRAS----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "AIR TRACK",
@@ -7293,7 +8504,9 @@
   {
     "sidc": "I*A*SRC-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "AIR TRACK",
@@ -7305,7 +8518,9 @@
   {
     "sidc": "I*A*SRD-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "AIR TRACK",
@@ -7317,7 +8532,9 @@
   {
     "sidc": "I*A*SRE-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "AIR TRACK",
@@ -7329,7 +8546,9 @@
   {
     "sidc": "I*A*SRF-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "AIR TRACK",
@@ -7341,7 +8560,9 @@
   {
     "sidc": "I*A*SRI-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "AIR TRACK",
@@ -7353,7 +8574,9 @@
   {
     "sidc": "I*A*SRMA----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "AIR TRACK",
@@ -7365,7 +8588,9 @@
   {
     "sidc": "I*A*SRMD----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "AIR TRACK",
@@ -7377,7 +8602,9 @@
   {
     "sidc": "I*A*SRMF----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "AIR TRACK",
@@ -7389,7 +8616,9 @@
   {
     "sidc": "I*A*SRMG----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "AIR TRACK",
@@ -7401,7 +8630,9 @@
   {
     "sidc": "I*A*SRMT----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "AIR TRACK",
@@ -7413,7 +8644,9 @@
   {
     "sidc": "I*A*SRTA----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "AIR TRACK",
@@ -7425,7 +8658,9 @@
   {
     "sidc": "I*A*SRTI----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "AIR TRACK",
@@ -7437,7 +8672,9 @@
   {
     "sidc": "I*A*SRTT----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "AIR TRACK",
@@ -7449,7 +8686,9 @@
   {
     "sidc": "I*A*SRU-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "AIR TRACK",
@@ -7461,7 +8700,9 @@
   {
     "sidc": "I*G*SCC-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "GROUND TRACK",
@@ -7473,7 +8714,9 @@
   {
     "sidc": "I*G*SCO-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "GROUND TRACK",
@@ -7485,7 +8728,9 @@
   {
     "sidc": "I*G*SCP-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "GROUND TRACK",
@@ -7497,7 +8742,9 @@
   {
     "sidc": "I*G*SCS-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "GROUND TRACK",
@@ -7509,7 +8756,9 @@
   {
     "sidc": "I*G*SCT-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "GROUND TRACK",
@@ -7521,7 +8770,9 @@
   {
     "sidc": "I*G*SRAA--*****",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "GROUND TRACK",
@@ -7533,7 +8784,9 @@
   {
     "sidc": "I*G*SRAT--*****",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "GROUND TRACK",
@@ -7545,7 +8798,9 @@
   {
     "sidc": "I*G*SRB---*****",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "GROUND TRACK",
@@ -7557,7 +8812,9 @@
   {
     "sidc": "I*G*SRCA----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "GROUND TRACK",
@@ -7569,7 +8826,9 @@
   {
     "sidc": "I*G*SRCS----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "GROUND TRACK",
@@ -7581,7 +8840,9 @@
   {
     "sidc": "I*G*SRD-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "GROUND TRACK",
@@ -7593,7 +8854,9 @@
   {
     "sidc": "I*G*SRE---*****",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "GROUND TRACK",
@@ -7605,7 +8868,9 @@
   {
     "sidc": "I*G*SRF---*****",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "GROUND TRACK",
@@ -7617,7 +8882,9 @@
   {
     "sidc": "I*G*SRH---*****",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "GROUND TRACK",
@@ -7629,7 +8896,9 @@
   {
     "sidc": "I*G*SRI---*****",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "GROUND TRACK",
@@ -7641,7 +8910,9 @@
   {
     "sidc": "I*G*SRMA----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "GROUND TRACK",
@@ -7653,7 +8924,9 @@
   {
     "sidc": "I*G*SRMF----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "GROUND TRACK",
@@ -7665,7 +8938,9 @@
   {
     "sidc": "I*G*SRMG----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "GROUND TRACK",
@@ -7677,7 +8952,9 @@
   {
     "sidc": "I*G*SRMM--*****",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "GROUND TRACK",
@@ -7689,7 +8966,9 @@
   {
     "sidc": "I*G*SRMT----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "GROUND TRACK",
@@ -7701,7 +8980,9 @@
   {
     "sidc": "I*G*SRS-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "GROUND TRACK",
@@ -7713,7 +8994,9 @@
   {
     "sidc": "I*G*SRTA----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "GROUND TRACK",
@@ -7725,7 +9008,9 @@
   {
     "sidc": "I*G*SRTI----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "GROUND TRACK",
@@ -7737,7 +9022,9 @@
   {
     "sidc": "I*G*SRTT----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "GROUND TRACK",
@@ -7749,7 +9036,9 @@
   {
     "sidc": "I*G*SRU-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "GROUND TRACK",
@@ -7761,7 +9050,9 @@
   {
     "sidc": "I*P*SCD-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SPACE, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "SPACE TRACK",
@@ -7773,7 +9064,9 @@
   {
     "sidc": "I*P*SRD-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SPACE, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "SPACE TRACK",
@@ -7785,7 +9078,9 @@
   {
     "sidc": "I*P*SRE-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SPACE, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "SPACE TRACK",
@@ -7797,7 +9092,9 @@
   {
     "sidc": "I*P*SRI-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SPACE, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "SPACE TRACK",
@@ -7809,7 +9106,9 @@
   {
     "sidc": "I*P*SRM-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SPACE, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "SPACE TRACK",
@@ -7821,7 +9120,9 @@
   {
     "sidc": "I*P*SRS-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SPACE, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "SPACE TRACK",
@@ -7833,7 +9134,9 @@
   {
     "sidc": "I*P*SRT-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SPACE, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "SPACE TRACK",
@@ -7845,7 +9148,9 @@
   {
     "sidc": "I*P*SRU-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SPACE, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "SPACE TRACK",
@@ -7857,7 +9162,9 @@
   {
     "sidc": "I*S*SCC-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "SEA SURFACE TRACK",
@@ -7869,7 +9176,9 @@
   {
     "sidc": "I*S*SCO-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "SEA SURFACE TRACK",
@@ -7881,7 +9190,9 @@
   {
     "sidc": "I*S*SCP-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "SEA SURFACE TRACK",
@@ -7893,7 +9204,9 @@
   {
     "sidc": "I*S*SCS-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "SEA SURFACE TRACK",
@@ -7905,7 +9218,9 @@
   {
     "sidc": "I*S*SRAA----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "SEA SURFACE TRACK",
@@ -7917,7 +9232,9 @@
   {
     "sidc": "I*S*SRAT----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "SEA SURFACE TRACK",
@@ -7929,7 +9246,9 @@
   {
     "sidc": "I*S*SRCA----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "SEA SURFACE TRACK",
@@ -7941,7 +9260,9 @@
   {
     "sidc": "I*S*SRCI----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "SEA SURFACE TRACK",
@@ -7953,7 +9274,9 @@
   {
     "sidc": "I*S*SRD-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "SEA SURFACE TRACK",
@@ -7965,7 +9288,9 @@
   {
     "sidc": "I*S*SRE-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "SEA SURFACE TRACK",
@@ -7977,7 +9302,9 @@
   {
     "sidc": "I*S*SRF-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "SEA SURFACE TRACK",
@@ -7989,7 +9316,9 @@
   {
     "sidc": "I*S*SRH-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "SEA SURFACE TRACK",
@@ -8001,7 +9330,9 @@
   {
     "sidc": "I*S*SRI-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "SEA SURFACE TRACK",
@@ -8013,7 +9344,9 @@
   {
     "sidc": "I*S*SRMA----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "SEA SURFACE TRACK",
@@ -8025,7 +9358,9 @@
   {
     "sidc": "I*S*SRMF----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "SEA SURFACE TRACK",
@@ -8037,7 +9372,9 @@
   {
     "sidc": "I*S*SRMG----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "SEA SURFACE TRACK",
@@ -8049,7 +9386,9 @@
   {
     "sidc": "I*S*SRMM----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "SEA SURFACE TRACK",
@@ -8061,7 +9400,9 @@
   {
     "sidc": "I*S*SRMT----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "SEA SURFACE TRACK",
@@ -8073,7 +9414,9 @@
   {
     "sidc": "I*S*SRS-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "SEA SURFACE TRACK",
@@ -8085,7 +9428,9 @@
   {
     "sidc": "I*S*SRTA----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "SEA SURFACE TRACK",
@@ -8097,7 +9442,9 @@
   {
     "sidc": "I*S*SRTI----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "SEA SURFACE TRACK",
@@ -8109,7 +9456,9 @@
   {
     "sidc": "I*S*SRTT----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "SEA SURFACE TRACK",
@@ -8121,7 +9470,9 @@
   {
     "sidc": "I*S*SRU-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "SEA SURFACE TRACK",
@@ -8133,7 +9484,9 @@
   {
     "sidc": "I*U*SCO-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "SUBSURFACE TRACK",
@@ -8145,7 +9498,9 @@
   {
     "sidc": "I*U*SCP-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "SUBSURFACE TRACK",
@@ -8157,7 +9512,9 @@
   {
     "sidc": "I*U*SCS-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "SUBSURFACE TRACK",
@@ -8169,7 +9526,9 @@
   {
     "sidc": "I*U*SRD-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "SUBSURFACE TRACK",
@@ -8181,7 +9540,9 @@
   {
     "sidc": "I*U*SRE-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "SUBSURFACE TRACK",
@@ -8193,7 +9554,9 @@
   {
     "sidc": "I*U*SRM-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "SUBSURFACE TRACK",
@@ -8205,7 +9568,9 @@
   {
     "sidc": "I*U*SRS---*****",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "SUBSURFACE TRACK",
@@ -8217,7 +9582,9 @@
   {
     "sidc": "I*U*SRT-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "SUBSURFACE TRACK",
@@ -8229,7 +9596,9 @@
   {
     "sidc": "I*U*SRU-----***",
     "class": "SI",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE, SIGINT",
     "hierarchy": [
       "SIGNALS INTELLIGENCE",
       "SUBSURFACE TRACK",
@@ -8310,7 +9679,9 @@
   {
     "sidc": "O*I*D-----*****",
     "class": "SO",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "ITEMS",
@@ -8320,7 +9691,9 @@
   {
     "sidc": "O*I*F-----*****",
     "class": "SO",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "SO",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "ITEMS",
@@ -8330,7 +9703,9 @@
   {
     "sidc": "O*I*G-----*****",
     "class": "SO",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "SO",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "ITEMS",
@@ -8340,7 +9715,9 @@
   {
     "sidc": "O*I*I-----*****",
     "class": "SO",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "ITEMS",
@@ -8350,7 +9727,9 @@
   {
     "sidc": "O*I*R-----*****",
     "class": "SO",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "SO",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "ITEMS",
@@ -8360,6 +9739,7 @@
   {
     "sidc": "O*I*S-----*****",
     "class": "SO",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
@@ -8370,7 +9750,9 @@
   {
     "sidc": "O*I*V-----*****",
     "class": "SO",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "SO",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "ITEMS",
@@ -8380,6 +9762,7 @@
   {
     "sidc": "O*L*B-----*****",
     "class": "SO",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
@@ -8390,6 +9773,7 @@
   {
     "sidc": "O*L*G-----*****",
     "class": "SO",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
@@ -8400,6 +9784,7 @@
   {
     "sidc": "O*L*M-----*****",
     "class": "SO",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
@@ -8410,6 +9795,7 @@
   {
     "sidc": "O*L*W-----*****",
     "class": "SO",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
@@ -8420,7 +9806,9 @@
   {
     "sidc": "O*O*A-----*****",
     "class": "SO",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "SO",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "OPERATIONS",
@@ -8430,7 +9818,9 @@
   {
     "sidc": "O*O*C-----*****",
     "class": "SO",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "SO",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "OPERATIONS",
@@ -8440,7 +9830,9 @@
   {
     "sidc": "O*O*CA----*****",
     "class": "SO",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "SO",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "OPERATIONS",
@@ -8450,7 +9842,9 @@
   {
     "sidc": "O*O*CB----*****",
     "class": "SO",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "SO",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "OPERATIONS",
@@ -8460,7 +9854,9 @@
   {
     "sidc": "O*O*CC----*****",
     "class": "SO",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "SO",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "OPERATIONS",
@@ -8470,7 +9866,9 @@
   {
     "sidc": "O*O*D-----*****",
     "class": "SO",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "SO",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "OPERATIONS",
@@ -8480,7 +9878,9 @@
   {
     "sidc": "O*O*E-----*****",
     "class": "SO",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "SO",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "OPERATIONS",
@@ -8490,7 +9890,9 @@
   {
     "sidc": "O*O*F-----*****",
     "class": "SO",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "SO",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "OPERATIONS",
@@ -8500,7 +9902,9 @@
   {
     "sidc": "O*O*HA----*****",
     "class": "SO",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "SO",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "OPERATIONS",
@@ -8510,7 +9914,9 @@
   {
     "sidc": "O*O*HT----*****",
     "class": "SO",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "SO",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "OPERATIONS",
@@ -8520,7 +9926,9 @@
   {
     "sidc": "O*O*HV----*****",
     "class": "SO",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "SO",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "OPERATIONS",
@@ -8530,7 +9938,9 @@
   {
     "sidc": "O*O*K-----*****",
     "class": "SO",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "SO",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "OPERATIONS",
@@ -8540,7 +9950,9 @@
   {
     "sidc": "O*O*KA----*****",
     "class": "SO",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "SO",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "OPERATIONS",
@@ -8550,7 +9962,9 @@
   {
     "sidc": "O*O*M-----*****",
     "class": "SO",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "SO",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "OPERATIONS",
@@ -8560,7 +9974,9 @@
   {
     "sidc": "O*O*O-----*****",
     "class": "SO",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "SO",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "OPERATIONS",
@@ -8570,7 +9986,9 @@
   {
     "sidc": "O*O*P-----*****",
     "class": "SO",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "SO",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "OPERATIONS",
@@ -8580,7 +9998,9 @@
   {
     "sidc": "O*O*RC----*****",
     "class": "SO",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "SO",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "OPERATIONS",
@@ -8590,7 +10010,9 @@
   {
     "sidc": "O*O*RW----*****",
     "class": "SO",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "SO",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "OPERATIONS",
@@ -8600,7 +10022,9 @@
   {
     "sidc": "O*O*S-----*****",
     "class": "SO",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "SO",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "OPERATIONS",
@@ -8610,7 +10034,9 @@
   {
     "sidc": "O*O*U-----*****",
     "class": "SO",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "SO",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "OPERATIONS",
@@ -8620,7 +10046,9 @@
   {
     "sidc": "O*O*Y-----*****",
     "class": "SO",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "SO",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "PSYCHOLOGICAL OPERATIONS (PSYOP)"
@@ -8629,7 +10057,9 @@
   {
     "sidc": "O*O*YH----*****",
     "class": "SO",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "SO",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "PSYCHOLOGICAL OPERATIONS (PSYOP)",
@@ -8639,7 +10069,9 @@
   {
     "sidc": "O*O*YT----*****",
     "class": "SO",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "SO",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "PSYCHOLOGICAL OPERATIONS (PSYOP)",
@@ -8649,7 +10081,9 @@
   {
     "sidc": "O*O*YW----*****",
     "class": "SO",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "SO",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "PSYCHOLOGICAL OPERATIONS (PSYOP)",
@@ -8659,6 +10093,7 @@
   {
     "sidc": "O*P*------*****",
     "class": "SO",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
@@ -8668,6 +10103,7 @@
   {
     "sidc": "O*P*A-----*****",
     "class": "SO",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
@@ -8677,6 +10113,7 @@
   {
     "sidc": "O*P*B-----*****",
     "class": "SO",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
@@ -8686,6 +10123,7 @@
   {
     "sidc": "O*P*C-----*****",
     "class": "SO",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
@@ -8695,7 +10133,9 @@
   {
     "sidc": "O*R*------*****",
     "class": "SO",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "SO",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "RAPE"
@@ -8704,7 +10144,9 @@
   {
     "sidc": "O*R*A-----*****",
     "class": "SO",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "SO",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "RAPE ATTEMPTED"
@@ -8713,7 +10155,9 @@
   {
     "sidc": "O*V*A-----*****",
     "class": "SO",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "SO",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "VIOLENT ACTIVITIES (DEATH CAUSING)",
@@ -8723,7 +10167,9 @@
   {
     "sidc": "O*V*B-----*****",
     "class": "SO",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "SO",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "VIOLENT ACTIVITIES (DEATH CAUSING)",
@@ -8733,7 +10179,9 @@
   {
     "sidc": "O*V*D-----*****",
     "class": "SO",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "SO",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "VIOLENT ACTIVITIES (DEATH CAUSING)",
@@ -8743,7 +10191,9 @@
   {
     "sidc": "O*V*E-----*****",
     "class": "SO",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "SO",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "VIOLENT ACTIVITIES (DEATH CAUSING)",
@@ -8753,7 +10203,9 @@
   {
     "sidc": "O*V*EI----*****",
     "class": "SO",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "SO",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "VIOLENT ACTIVITIES (DEATH CAUSING)",
@@ -8763,7 +10215,9 @@
   {
     "sidc": "O*V*M-----*****",
     "class": "SO",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "SO",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "VIOLENT ACTIVITIES (DEATH CAUSING)",
@@ -8773,7 +10227,9 @@
   {
     "sidc": "O*V*MA----*****",
     "class": "SO",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "SO",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "VIOLENT ACTIVITIES (DEATH CAUSING)",
@@ -8784,7 +10240,9 @@
   {
     "sidc": "O*V*MB----*****",
     "class": "SO",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "SO",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "VIOLENT ACTIVITIES (DEATH CAUSING)",
@@ -8795,7 +10253,9 @@
   {
     "sidc": "O*V*MC----*****",
     "class": "SO",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "SO",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "VIOLENT ACTIVITIES (DEATH CAUSING)",
@@ -8806,7 +10266,9 @@
   {
     "sidc": "O*V*P-----*****",
     "class": "SO",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "SO",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "VIOLENT ACTIVITIES (DEATH CAUSING)",
@@ -8816,7 +10278,9 @@
   {
     "sidc": "O*V*S-----*****",
     "class": "SO",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "SO",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "VIOLENT ACTIVITIES (DEATH CAUSING)",
@@ -8826,7 +10290,9 @@
   {
     "sidc": "O*V*Y-----*****",
     "class": "SO",
+    "scope": "ACTIVITY",
     "geometry": "Point",
+    "dimension": "SO",
     "hierarchy": [
       "STABILITY OPERATIONS (SO)",
       "VIOLENT ACTIVITIES (DEATH CAUSING)",
@@ -8836,7 +10302,9 @@
   {
     "sidc": "S*A*------*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK"
@@ -8845,7 +10313,9 @@
   {
     "sidc": "S*A*C-----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -8855,7 +10325,9 @@
   {
     "sidc": "S*A*CF----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -8866,7 +10338,9 @@
   {
     "sidc": "S*A*CH----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -8877,7 +10351,9 @@
   {
     "sidc": "S*A*CL----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -8888,7 +10364,9 @@
   {
     "sidc": "S*A*M-----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -8898,7 +10376,9 @@
   {
     "sidc": "S*A*ME----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -8909,7 +10389,9 @@
   {
     "sidc": "S*A*MF----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -8920,7 +10402,9 @@
   {
     "sidc": "S*A*MFA---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -8932,7 +10416,9 @@
   {
     "sidc": "S*A*MFB---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -8944,7 +10430,9 @@
   {
     "sidc": "S*A*MFC---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -8956,7 +10444,9 @@
   {
     "sidc": "S*A*MFCH--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -8969,7 +10459,9 @@
   {
     "sidc": "S*A*MFCL--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -8982,7 +10474,9 @@
   {
     "sidc": "S*A*MFCM--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -8995,7 +10489,9 @@
   {
     "sidc": "S*A*MFD---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9007,7 +10503,9 @@
   {
     "sidc": "S*A*MFF---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9019,7 +10517,9 @@
   {
     "sidc": "S*A*MFFI--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9032,7 +10532,9 @@
   {
     "sidc": "S*A*MFH---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9044,7 +10546,9 @@
   {
     "sidc": "S*A*MFJ---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9056,7 +10560,9 @@
   {
     "sidc": "S*A*MFK---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9068,7 +10574,9 @@
   {
     "sidc": "S*A*MFKB--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9080,7 +10588,9 @@
   {
     "sidc": "S*A*MFKD--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9092,7 +10602,9 @@
   {
     "sidc": "S*A*MFL---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9104,7 +10616,9 @@
   {
     "sidc": "S*A*MFM---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9116,7 +10630,9 @@
   {
     "sidc": "S*A*MFO---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9128,7 +10644,9 @@
   {
     "sidc": "S*A*MFP---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9140,7 +10658,9 @@
   {
     "sidc": "S*A*MFPM--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9153,7 +10673,9 @@
   {
     "sidc": "S*A*MFPN--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9166,7 +10688,9 @@
   {
     "sidc": "S*A*MFQ---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9178,7 +10702,9 @@
   {
     "sidc": "S*A*MFQA--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9191,7 +10717,9 @@
   {
     "sidc": "S*A*MFQB--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9204,7 +10732,9 @@
   {
     "sidc": "S*A*MFQC--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9217,7 +10747,9 @@
   {
     "sidc": "S*A*MFQD--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9230,7 +10762,9 @@
   {
     "sidc": "S*A*MFQF--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9243,7 +10777,9 @@
   {
     "sidc": "S*A*MFQH--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9256,7 +10792,9 @@
   {
     "sidc": "S*A*MFQI--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9269,7 +10807,9 @@
   {
     "sidc": "S*A*MFQJ--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9282,7 +10822,9 @@
   {
     "sidc": "S*A*MFQK--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9295,7 +10837,9 @@
   {
     "sidc": "S*A*MFQL--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9308,7 +10852,9 @@
   {
     "sidc": "S*A*MFQM--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9321,7 +10867,9 @@
   {
     "sidc": "S*A*MFQN--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9334,7 +10882,9 @@
   {
     "sidc": "S*A*MFQO--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9347,7 +10897,9 @@
   {
     "sidc": "S*A*MFQP--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9360,7 +10912,9 @@
   {
     "sidc": "S*A*MFQR--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9373,7 +10927,9 @@
   {
     "sidc": "S*A*MFQRW-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9387,7 +10943,9 @@
   {
     "sidc": "S*A*MFQRX-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9401,7 +10959,9 @@
   {
     "sidc": "S*A*MFQRZ-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9415,7 +10975,9 @@
   {
     "sidc": "S*A*MFQS--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9428,7 +10990,9 @@
   {
     "sidc": "S*A*MFQT--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9441,7 +11005,9 @@
   {
     "sidc": "S*A*MFQU--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9454,7 +11020,9 @@
   {
     "sidc": "S*A*MFQY--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9467,7 +11035,9 @@
   {
     "sidc": "S*A*MFR---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9479,7 +11049,9 @@
   {
     "sidc": "S*A*MFRW--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9492,7 +11064,9 @@
   {
     "sidc": "S*A*MFRX--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9505,7 +11079,9 @@
   {
     "sidc": "S*A*MFRZ--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9518,7 +11094,9 @@
   {
     "sidc": "S*A*MFS---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9530,7 +11108,9 @@
   {
     "sidc": "S*A*MFT---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9542,7 +11122,9 @@
   {
     "sidc": "S*A*MFU---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9554,7 +11136,9 @@
   {
     "sidc": "S*A*MFUH--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9566,7 +11150,9 @@
   {
     "sidc": "S*A*MFUL--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9578,7 +11164,9 @@
   {
     "sidc": "S*A*MFUM--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9590,7 +11178,9 @@
   {
     "sidc": "S*A*MFY---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9602,7 +11192,9 @@
   {
     "sidc": "S*A*MH----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9613,7 +11205,9 @@
   {
     "sidc": "S*A*MHA---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9625,7 +11219,9 @@
   {
     "sidc": "S*A*MHC---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9637,7 +11233,9 @@
   {
     "sidc": "S*A*MHCH--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9650,7 +11248,9 @@
   {
     "sidc": "S*A*MHCL--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9663,7 +11263,9 @@
   {
     "sidc": "S*A*MHCM--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9676,7 +11278,9 @@
   {
     "sidc": "S*A*MHD---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9688,7 +11292,9 @@
   {
     "sidc": "S*A*MHH---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9700,7 +11306,9 @@
   {
     "sidc": "S*A*MHI---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9712,7 +11320,9 @@
   {
     "sidc": "S*A*MHJ---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9724,7 +11334,9 @@
   {
     "sidc": "S*A*MHK---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9736,7 +11348,9 @@
   {
     "sidc": "S*A*MHM---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9748,7 +11362,9 @@
   {
     "sidc": "S*A*MHO---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9760,7 +11376,9 @@
   {
     "sidc": "S*A*MHQ---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9772,7 +11390,9 @@
   {
     "sidc": "S*A*MHR---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9784,7 +11404,9 @@
   {
     "sidc": "S*A*MHS---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9796,7 +11418,9 @@
   {
     "sidc": "S*A*MHT---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9808,7 +11432,9 @@
   {
     "sidc": "S*A*MHU---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9820,7 +11446,9 @@
   {
     "sidc": "S*A*MHUH--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9832,7 +11460,9 @@
   {
     "sidc": "S*A*MHUL--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9844,7 +11474,9 @@
   {
     "sidc": "S*A*MHUM--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9856,7 +11488,9 @@
   {
     "sidc": "S*A*ML----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9867,7 +11501,9 @@
   {
     "sidc": "S*A*MV----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9878,7 +11514,9 @@
   {
     "sidc": "S*A*W-----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9888,7 +11526,9 @@
   {
     "sidc": "S*A*WB----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9899,7 +11539,9 @@
   {
     "sidc": "S*A*WD----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9910,7 +11552,9 @@
   {
     "sidc": "S*A*WM----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9921,7 +11565,9 @@
   {
     "sidc": "S*A*WMA---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9933,7 +11579,9 @@
   {
     "sidc": "S*A*WMAA--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9946,7 +11594,9 @@
   {
     "sidc": "S*A*WMAP--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9959,7 +11609,9 @@
   {
     "sidc": "S*A*WMAS--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9972,7 +11624,9 @@
   {
     "sidc": "S*A*WMB---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9984,7 +11638,9 @@
   {
     "sidc": "S*A*WMC---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -9996,7 +11652,9 @@
   {
     "sidc": "S*A*WMS---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -10008,7 +11666,9 @@
   {
     "sidc": "S*A*WMSA--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -10021,7 +11681,9 @@
   {
     "sidc": "S*A*WMSB--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -10034,7 +11696,9 @@
   {
     "sidc": "S*A*WMSS--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -10047,7 +11711,9 @@
   {
     "sidc": "S*A*WMSU--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -10060,7 +11726,9 @@
   {
     "sidc": "S*A*WMU---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "AIR",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "AIR TRACK",
@@ -10072,7 +11740,9 @@
   {
     "sidc": "S*F*------*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
+    "dimension": "SOF",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SPECIAL OPERATIONS FORCES (SOF) UNIT"
@@ -10081,7 +11751,9 @@
   {
     "sidc": "S*F*A-----*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
+    "dimension": "SOF",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SPECIAL OPERATIONS FORCES (SOF) UNIT",
@@ -10091,7 +11763,9 @@
   {
     "sidc": "S*F*AF----*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
+    "dimension": "SOF",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SPECIAL OPERATIONS FORCES (SOF) UNIT",
@@ -10102,7 +11776,9 @@
   {
     "sidc": "S*F*AFA---*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
+    "dimension": "SOF",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SPECIAL OPERATIONS FORCES (SOF) UNIT",
@@ -10114,7 +11790,9 @@
   {
     "sidc": "S*F*AFK---*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
+    "dimension": "SOF",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SPECIAL OPERATIONS FORCES (SOF) UNIT",
@@ -10126,7 +11804,9 @@
   {
     "sidc": "S*F*AFU---*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
+    "dimension": "SOF",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SPECIAL OPERATIONS FORCES (SOF) UNIT",
@@ -10138,7 +11818,9 @@
   {
     "sidc": "S*F*AFUH--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
+    "dimension": "SOF",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SPECIAL OPERATIONS FORCES (SOF) UNIT",
@@ -10150,7 +11832,9 @@
   {
     "sidc": "S*F*AFUL--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
+    "dimension": "SOF",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SPECIAL OPERATIONS FORCES (SOF) UNIT",
@@ -10162,7 +11846,9 @@
   {
     "sidc": "S*F*AFUM--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
+    "dimension": "SOF",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SPECIAL OPERATIONS FORCES (SOF) UNIT",
@@ -10174,7 +11860,9 @@
   {
     "sidc": "S*F*AH----*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
+    "dimension": "SOF",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SPECIAL OPERATIONS FORCES (SOF) UNIT",
@@ -10185,7 +11873,9 @@
   {
     "sidc": "S*F*AHA---*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
+    "dimension": "SOF",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SPECIAL OPERATIONS FORCES (SOF) UNIT",
@@ -10197,7 +11887,9 @@
   {
     "sidc": "S*F*AHH---*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
+    "dimension": "SOF",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SPECIAL OPERATIONS FORCES (SOF) UNIT",
@@ -10209,7 +11901,9 @@
   {
     "sidc": "S*F*AHU---*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
+    "dimension": "SOF",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SPECIAL OPERATIONS FORCES (SOF) UNIT",
@@ -10221,7 +11915,9 @@
   {
     "sidc": "S*F*AHUH--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
+    "dimension": "SOF",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SPECIAL OPERATIONS FORCES (SOF) UNIT",
@@ -10233,7 +11929,9 @@
   {
     "sidc": "S*F*AHUL--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
+    "dimension": "SOF",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SPECIAL OPERATIONS FORCES (SOF) UNIT",
@@ -10245,7 +11943,9 @@
   {
     "sidc": "S*F*AHUM--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
+    "dimension": "SOF",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SPECIAL OPERATIONS FORCES (SOF) UNIT",
@@ -10257,7 +11957,9 @@
   {
     "sidc": "S*F*AV----*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
+    "dimension": "SOF",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SPECIAL OPERATIONS FORCES (SOF) UNIT",
@@ -10268,7 +11970,9 @@
   {
     "sidc": "S*F*B-----*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
+    "dimension": "SOF",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SPECIAL OPERATIONS FORCES (SOF) UNIT",
@@ -10278,7 +11982,9 @@
   {
     "sidc": "S*F*G-----*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
+    "dimension": "SOF",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SPECIAL OPERATIONS FORCES (SOF) UNIT",
@@ -10288,7 +11994,9 @@
   {
     "sidc": "S*F*GC----*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
+    "dimension": "SOF",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SPECIAL OPERATIONS FORCES (SOF) UNIT",
@@ -10299,7 +12007,9 @@
   {
     "sidc": "S*F*GP----*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
+    "dimension": "SOF",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SPECIAL OPERATIONS FORCES (SOF) UNIT",
@@ -10310,7 +12020,9 @@
   {
     "sidc": "S*F*GPA---*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
+    "dimension": "SOF",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SPECIAL OPERATIONS FORCES (SOF) UNIT",
@@ -10322,7 +12034,9 @@
   {
     "sidc": "S*F*GR----*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
+    "dimension": "SOF",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SPECIAL OPERATIONS FORCES (SOF) UNIT",
@@ -10333,7 +12047,9 @@
   {
     "sidc": "S*F*GS----*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
+    "dimension": "SOF",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SPECIAL OPERATIONS FORCES (SOF) UNIT",
@@ -10344,7 +12060,9 @@
   {
     "sidc": "S*F*N-----*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
+    "dimension": "SOF",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SPECIAL OPERATIONS FORCES (SOF) UNIT",
@@ -10354,7 +12072,9 @@
   {
     "sidc": "S*F*NB----*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
+    "dimension": "SOF",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SPECIAL OPERATIONS FORCES (SOF) UNIT",
@@ -10365,7 +12085,9 @@
   {
     "sidc": "S*F*NN----*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
+    "dimension": "SOF",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SPECIAL OPERATIONS FORCES (SOF) UNIT",
@@ -10376,7 +12098,9 @@
   {
     "sidc": "S*F*NS----*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
+    "dimension": "SOF",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SPECIAL OPERATIONS FORCES (SOF) UNIT",
@@ -10387,7 +12111,9 @@
   {
     "sidc": "S*F*NU----*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
+    "dimension": "SOF",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SPECIAL OPERATIONS FORCES (SOF) UNIT",
@@ -10406,7 +12132,9 @@
   {
     "sidc": "S*G*E-----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT"
@@ -10415,7 +12143,9 @@
   {
     "sidc": "S*G*ES----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10425,7 +12155,9 @@
   {
     "sidc": "S*G*ESE---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10435,7 +12167,9 @@
   {
     "sidc": "S*G*ESR---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10446,7 +12180,9 @@
   {
     "sidc": "S*G*ESR---H-***",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10457,7 +12193,9 @@
   {
     "sidc": "S*G*EV----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10467,7 +12205,9 @@
   {
     "sidc": "S*G*EVA---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10478,7 +12218,9 @@
   {
     "sidc": "S*G*EVAA--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10490,7 +12232,9 @@
   {
     "sidc": "S*G*EVAAR-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10502,7 +12246,9 @@
   {
     "sidc": "S*G*EVAC--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10514,7 +12260,9 @@
   {
     "sidc": "S*G*EVAI--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10526,7 +12274,9 @@
   {
     "sidc": "S*G*EVAL--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10537,7 +12287,9 @@
   {
     "sidc": "S*G*EVAS--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10549,7 +12301,9 @@
   {
     "sidc": "S*G*EVAT--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10561,7 +12315,9 @@
   {
     "sidc": "S*G*EVATH-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10573,7 +12329,9 @@
   {
     "sidc": "S*G*EVATHR*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10585,7 +12343,9 @@
   {
     "sidc": "S*G*EVATL-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10597,7 +12357,9 @@
   {
     "sidc": "S*G*EVATLR*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10609,7 +12371,9 @@
   {
     "sidc": "S*G*EVATM-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10621,7 +12385,9 @@
   {
     "sidc": "S*G*EVATMR*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10633,7 +12399,9 @@
   {
     "sidc": "S*G*EVC---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10644,7 +12412,9 @@
   {
     "sidc": "S*G*EVCA--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10656,7 +12426,9 @@
   {
     "sidc": "S*G*EVCAH-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10668,7 +12440,9 @@
   {
     "sidc": "S*G*EVCAL-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10680,7 +12454,9 @@
   {
     "sidc": "S*G*EVCAM-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10692,7 +12468,9 @@
   {
     "sidc": "S*G*EVCF--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10704,7 +12482,9 @@
   {
     "sidc": "S*G*EVCFH-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10717,7 +12497,9 @@
   {
     "sidc": "S*G*EVCFL-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10730,7 +12512,9 @@
   {
     "sidc": "S*G*EVCFM-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10743,7 +12527,9 @@
   {
     "sidc": "S*G*EVCJ--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10755,7 +12541,9 @@
   {
     "sidc": "S*G*EVCJH-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10767,7 +12555,9 @@
   {
     "sidc": "S*G*EVCJL-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10779,7 +12569,9 @@
   {
     "sidc": "S*G*EVCJM-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10791,7 +12583,9 @@
   {
     "sidc": "S*G*EVCM--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10803,7 +12597,9 @@
   {
     "sidc": "S*G*EVCMH-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10815,7 +12611,9 @@
   {
     "sidc": "S*G*EVCML-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10827,7 +12625,9 @@
   {
     "sidc": "S*G*EVCMM-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10839,7 +12639,9 @@
   {
     "sidc": "S*G*EVCO--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10851,7 +12653,9 @@
   {
     "sidc": "S*G*EVCOH-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10863,7 +12667,9 @@
   {
     "sidc": "S*G*EVCOL-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10875,7 +12681,9 @@
   {
     "sidc": "S*G*EVCOM-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10887,7 +12695,9 @@
   {
     "sidc": "S*G*EVCT--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10899,7 +12709,9 @@
   {
     "sidc": "S*G*EVCTH-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10912,7 +12724,9 @@
   {
     "sidc": "S*G*EVCTL-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10925,7 +12739,9 @@
   {
     "sidc": "S*G*EVCTM-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10938,7 +12754,9 @@
   {
     "sidc": "S*G*EVCU--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10950,7 +12768,9 @@
   {
     "sidc": "S*G*EVCUH-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10962,7 +12782,9 @@
   {
     "sidc": "S*G*EVCUL-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10974,7 +12796,9 @@
   {
     "sidc": "S*G*EVCUM-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10986,7 +12810,9 @@
   {
     "sidc": "S*G*EVE---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -10997,7 +12823,9 @@
   {
     "sidc": "S*G*EVEA--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11009,7 +12837,9 @@
   {
     "sidc": "S*G*EVEAA-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11021,7 +12851,9 @@
   {
     "sidc": "S*G*EVEAT-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11033,7 +12865,9 @@
   {
     "sidc": "S*G*EVEB--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11045,7 +12879,9 @@
   {
     "sidc": "S*G*EVEC--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11057,7 +12893,9 @@
   {
     "sidc": "S*G*EVED--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11069,7 +12907,9 @@
   {
     "sidc": "S*G*EVEDA-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11081,7 +12921,9 @@
   {
     "sidc": "S*G*EVEE--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11093,7 +12935,9 @@
   {
     "sidc": "S*G*EVEF--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11105,7 +12949,9 @@
   {
     "sidc": "S*G*EVEH--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11117,7 +12963,9 @@
   {
     "sidc": "S*G*EVEM--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11129,7 +12977,9 @@
   {
     "sidc": "S*G*EVEML-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11142,7 +12992,9 @@
   {
     "sidc": "S*G*EVEMV-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11155,7 +13007,9 @@
   {
     "sidc": "S*G*EVER--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11167,7 +13021,9 @@
   {
     "sidc": "S*G*EVES--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11179,7 +13035,9 @@
   {
     "sidc": "S*G*EVM---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11190,7 +13048,9 @@
   {
     "sidc": "S*G*EVS---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11201,7 +13061,9 @@
   {
     "sidc": "S*G*EVSC--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11212,7 +13074,9 @@
   {
     "sidc": "S*G*EVSP--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11223,7 +13087,9 @@
   {
     "sidc": "S*G*EVSR--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11234,7 +13100,9 @@
   {
     "sidc": "S*G*EVST--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11245,7 +13113,9 @@
   {
     "sidc": "S*G*EVSW--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11256,7 +13126,9 @@
   {
     "sidc": "S*G*EVT---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11267,7 +13139,9 @@
   {
     "sidc": "S*G*EVU---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11278,7 +13152,9 @@
   {
     "sidc": "S*G*EVUA--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11290,7 +13166,9 @@
   {
     "sidc": "S*G*EVUAA-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11302,7 +13180,9 @@
   {
     "sidc": "S*G*EVUB--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11314,7 +13194,9 @@
   {
     "sidc": "S*G*EVUL--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11326,7 +13208,9 @@
   {
     "sidc": "S*G*EVUR--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11338,7 +13222,9 @@
   {
     "sidc": "S*G*EVUS--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11350,7 +13236,9 @@
   {
     "sidc": "S*G*EVUSH-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11362,7 +13250,9 @@
   {
     "sidc": "S*G*EVUSL-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11374,7 +13264,9 @@
   {
     "sidc": "S*G*EVUSM-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11386,7 +13278,9 @@
   {
     "sidc": "S*G*EVUT--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11398,7 +13292,9 @@
   {
     "sidc": "S*G*EVUTH-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11410,7 +13306,9 @@
   {
     "sidc": "S*G*EVUTL-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11422,7 +13320,9 @@
   {
     "sidc": "S*G*EVUX--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11434,7 +13334,9 @@
   {
     "sidc": "S*G*EWA---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11445,7 +13347,9 @@
   {
     "sidc": "S*G*EWAH--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11456,7 +13360,9 @@
   {
     "sidc": "S*G*EWAL--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11467,7 +13373,9 @@
   {
     "sidc": "S*G*EWAM--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11478,7 +13386,9 @@
   {
     "sidc": "S*G*EWD---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11489,7 +13399,9 @@
   {
     "sidc": "S*G*EWDH--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11500,7 +13412,9 @@
   {
     "sidc": "S*G*EWDHS-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11511,7 +13425,9 @@
   {
     "sidc": "S*G*EWDL--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11522,7 +13438,9 @@
   {
     "sidc": "S*G*EWDLS-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11533,7 +13451,9 @@
   {
     "sidc": "S*G*EWDM--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11544,7 +13464,9 @@
   {
     "sidc": "S*G*EWDMS-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11555,7 +13477,9 @@
   {
     "sidc": "S*G*EWG---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11566,7 +13490,9 @@
   {
     "sidc": "S*G*EWGH--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11577,7 +13503,9 @@
   {
     "sidc": "S*G*EWGL--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11588,7 +13516,9 @@
   {
     "sidc": "S*G*EWGM--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11599,7 +13529,9 @@
   {
     "sidc": "S*G*EWGR--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11610,7 +13542,9 @@
   {
     "sidc": "S*G*EWH---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11621,7 +13555,9 @@
   {
     "sidc": "S*G*EWHH--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11632,7 +13568,9 @@
   {
     "sidc": "S*G*EWHHS-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11643,7 +13581,9 @@
   {
     "sidc": "S*G*EWHL--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11654,7 +13594,9 @@
   {
     "sidc": "S*G*EWHLS-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11665,7 +13607,9 @@
   {
     "sidc": "S*G*EWHM--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11676,7 +13620,9 @@
   {
     "sidc": "S*G*EWHMS-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11687,7 +13633,9 @@
   {
     "sidc": "S*G*EWM---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11698,7 +13646,9 @@
   {
     "sidc": "S*G*EWMA--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11709,7 +13659,9 @@
   {
     "sidc": "S*G*EWMAI-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11721,7 +13673,9 @@
   {
     "sidc": "S*G*EWMAIE*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11734,7 +13688,9 @@
   {
     "sidc": "S*G*EWMAIR*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11747,7 +13703,9 @@
   {
     "sidc": "S*G*EWMAL-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11759,7 +13717,9 @@
   {
     "sidc": "S*G*EWMALE*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11772,7 +13732,9 @@
   {
     "sidc": "S*G*EWMALR*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11785,7 +13747,9 @@
   {
     "sidc": "S*G*EWMAS-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11797,7 +13761,9 @@
   {
     "sidc": "S*G*EWMASE*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11810,7 +13776,9 @@
   {
     "sidc": "S*G*EWMASR*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11823,7 +13791,9 @@
   {
     "sidc": "S*G*EWMAT-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11835,7 +13805,9 @@
   {
     "sidc": "S*G*EWMATE*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11848,7 +13820,9 @@
   {
     "sidc": "S*G*EWMATR*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11861,7 +13835,9 @@
   {
     "sidc": "S*G*EWMS--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11872,7 +13848,9 @@
   {
     "sidc": "S*G*EWMSI-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11884,7 +13862,9 @@
   {
     "sidc": "S*G*EWMSL-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11896,7 +13876,9 @@
   {
     "sidc": "S*G*EWMSS-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11908,7 +13890,9 @@
   {
     "sidc": "S*G*EWMT--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11919,7 +13903,9 @@
   {
     "sidc": "S*G*EWMTH-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11931,7 +13917,9 @@
   {
     "sidc": "S*G*EWMTL-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11943,7 +13931,9 @@
   {
     "sidc": "S*G*EWMTM-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11955,7 +13945,9 @@
   {
     "sidc": "S*G*EWO---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11966,7 +13958,9 @@
   {
     "sidc": "S*G*EWOH--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11977,7 +13971,9 @@
   {
     "sidc": "S*G*EWOL--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11988,7 +13984,9 @@
   {
     "sidc": "S*G*EWOM--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -11999,7 +13997,9 @@
   {
     "sidc": "S*G*EWR---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -12009,7 +14009,9 @@
   {
     "sidc": "S*G*EWRH--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -12020,7 +14022,9 @@
   {
     "sidc": "S*G*EWRL--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -12031,7 +14035,9 @@
   {
     "sidc": "S*G*EWRR--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -12042,7 +14048,9 @@
   {
     "sidc": "S*G*EWS---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -12053,7 +14061,9 @@
   {
     "sidc": "S*G*EWSH--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -12064,7 +14074,9 @@
   {
     "sidc": "S*G*EWSL--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -12075,7 +14087,9 @@
   {
     "sidc": "S*G*EWSM--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -12086,7 +14100,9 @@
   {
     "sidc": "S*G*EWT---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -12097,7 +14113,9 @@
   {
     "sidc": "S*G*EWTH--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -12108,7 +14126,9 @@
   {
     "sidc": "S*G*EWTL--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -12119,7 +14139,9 @@
   {
     "sidc": "S*G*EWTM--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -12130,7 +14152,9 @@
   {
     "sidc": "S*G*EWX---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -12141,7 +14165,9 @@
   {
     "sidc": "S*G*EWXH--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -12152,7 +14178,9 @@
   {
     "sidc": "S*G*EWXL--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -12163,7 +14191,9 @@
   {
     "sidc": "S*G*EWXM--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -12174,7 +14204,9 @@
   {
     "sidc": "S*G*EWZ---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -12185,7 +14217,9 @@
   {
     "sidc": "S*G*EWZH--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -12196,7 +14230,9 @@
   {
     "sidc": "S*G*EWZL--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -12207,7 +14243,9 @@
   {
     "sidc": "S*G*EWZM--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -12218,7 +14256,9 @@
   {
     "sidc": "S*G*EXF---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -12229,7 +14269,9 @@
   {
     "sidc": "S*G*EXI---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -12240,7 +14282,9 @@
   {
     "sidc": "S*G*EXL---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -12251,7 +14295,9 @@
   {
     "sidc": "S*G*EXM---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -12262,7 +14308,9 @@
   {
     "sidc": "S*G*EXMC--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -12274,7 +14322,9 @@
   {
     "sidc": "S*G*EXML--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -12286,7 +14336,9 @@
   {
     "sidc": "S*G*EXN---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "LAND",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "GROUND TRACK EQUIPMENT",
@@ -12297,6 +14349,7 @@
   {
     "sidc": "S*G*I-----H****",
     "class": "I",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12307,6 +14360,7 @@
   {
     "sidc": "S*G*IB----H****",
     "class": "I",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12318,6 +14372,7 @@
   {
     "sidc": "S*G*IBA---H****",
     "class": "I",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12330,6 +14385,7 @@
   {
     "sidc": "S*G*IBN---H****",
     "class": "I",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12342,6 +14398,7 @@
   {
     "sidc": "S*G*IE----H****",
     "class": "I",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12353,6 +14410,7 @@
   {
     "sidc": "S*G*IG----H****",
     "class": "I",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12364,6 +14422,7 @@
   {
     "sidc": "S*G*IMA---H****",
     "class": "I",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12376,6 +14435,7 @@
   {
     "sidc": "S*G*IMC---H****",
     "class": "I",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12388,6 +14448,7 @@
   {
     "sidc": "S*G*IME---H****",
     "class": "I",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12400,6 +14461,7 @@
   {
     "sidc": "S*G*IMF---H****",
     "class": "I",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12412,6 +14474,7 @@
   {
     "sidc": "S*G*IMFA--H****",
     "class": "I",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12425,6 +14488,7 @@
   {
     "sidc": "S*G*IMFP--H****",
     "class": "I",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12438,6 +14502,7 @@
   {
     "sidc": "S*G*IMFPW-H****",
     "class": "I",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12452,6 +14517,7 @@
   {
     "sidc": "S*G*IMFS--H****",
     "class": "I",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12465,6 +14531,7 @@
   {
     "sidc": "S*G*IMG---H****",
     "class": "I",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12477,6 +14544,7 @@
   {
     "sidc": "S*G*IMM---H****",
     "class": "I",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12489,6 +14557,7 @@
   {
     "sidc": "S*G*IMN---H****",
     "class": "I",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12501,6 +14570,7 @@
   {
     "sidc": "S*G*IMNB--H****",
     "class": "I",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12514,6 +14584,7 @@
   {
     "sidc": "S*G*IMS---H****",
     "class": "I",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12526,6 +14597,7 @@
   {
     "sidc": "S*G*IMV---H****",
     "class": "I",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12538,6 +14610,7 @@
   {
     "sidc": "S*G*IP----H****",
     "class": "I",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12549,6 +14622,7 @@
   {
     "sidc": "S*G*IPD---H****",
     "class": "I",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12561,6 +14635,7 @@
   {
     "sidc": "S*G*IR----H****",
     "class": "I",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12572,6 +14647,7 @@
   {
     "sidc": "S*G*IRM---H****",
     "class": "I",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12584,6 +14660,7 @@
   {
     "sidc": "S*G*IRN---H****",
     "class": "I",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12596,6 +14673,7 @@
   {
     "sidc": "S*G*IRNB--H****",
     "class": "I",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12609,6 +14687,7 @@
   {
     "sidc": "S*G*IRNC--H****",
     "class": "I",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12622,6 +14701,7 @@
   {
     "sidc": "S*G*IRNN--H****",
     "class": "I",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12635,6 +14715,7 @@
   {
     "sidc": "S*G*IRP---H****",
     "class": "I",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12647,6 +14728,7 @@
   {
     "sidc": "S*G*IT----H****",
     "class": "I",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12658,6 +14740,7 @@
   {
     "sidc": "S*G*IU----H****",
     "class": "I",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12669,6 +14752,7 @@
   {
     "sidc": "S*G*IUE---H****",
     "class": "I",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12681,6 +14765,7 @@
   {
     "sidc": "S*G*IUED--H****",
     "class": "I",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12694,6 +14779,7 @@
   {
     "sidc": "S*G*IUEF--H****",
     "class": "I",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12707,6 +14793,7 @@
   {
     "sidc": "S*G*IUEN--H****",
     "class": "I",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12720,6 +14807,7 @@
   {
     "sidc": "S*G*IUP---H****",
     "class": "I",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12732,6 +14820,7 @@
   {
     "sidc": "S*G*IUR---H****",
     "class": "I",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12744,6 +14833,7 @@
   {
     "sidc": "S*G*IUT---H****",
     "class": "I",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12756,6 +14846,7 @@
   {
     "sidc": "S*G*IX----H****",
     "class": "I",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12767,6 +14858,7 @@
   {
     "sidc": "S*G*IXH---H****",
     "class": "I",
+    "scope": "INSTALLATION",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12779,6 +14871,7 @@
   {
     "sidc": "S*G*U-----*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12789,6 +14882,7 @@
   {
     "sidc": "S*G*UC----*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12800,6 +14894,7 @@
   {
     "sidc": "S*G*UCA---*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12812,6 +14907,7 @@
   {
     "sidc": "S*G*UCAA--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12824,6 +14920,7 @@
   {
     "sidc": "S*G*UCAAA-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12836,6 +14933,7 @@
   {
     "sidc": "S*G*UCAAAS*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12848,6 +14946,7 @@
   {
     "sidc": "S*G*UCAAAT*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12860,6 +14959,7 @@
   {
     "sidc": "S*G*UCAAAW*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12872,6 +14972,7 @@
   {
     "sidc": "S*G*UCAAC-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12884,6 +14985,7 @@
   {
     "sidc": "S*G*UCAAD-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12896,6 +14998,7 @@
   {
     "sidc": "S*G*UCAAL-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12908,6 +15011,7 @@
   {
     "sidc": "S*G*UCAAM-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12920,6 +15024,7 @@
   {
     "sidc": "S*G*UCAAO-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12932,6 +15037,7 @@
   {
     "sidc": "S*G*UCAAOS*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12944,6 +15050,7 @@
   {
     "sidc": "S*G*UCAAS-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12956,6 +15063,7 @@
   {
     "sidc": "S*G*UCAAU-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12968,6 +15076,7 @@
   {
     "sidc": "S*G*UCAT--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12980,6 +15089,7 @@
   {
     "sidc": "S*G*UCATA-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -12992,6 +15102,7 @@
   {
     "sidc": "S*G*UCATH-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13004,6 +15115,7 @@
   {
     "sidc": "S*G*UCATL-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13016,6 +15128,7 @@
   {
     "sidc": "S*G*UCATM-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13028,6 +15141,7 @@
   {
     "sidc": "S*G*UCATR-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13040,6 +15154,7 @@
   {
     "sidc": "S*G*UCATW-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13052,6 +15167,7 @@
   {
     "sidc": "S*G*UCATWR*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13064,6 +15180,7 @@
   {
     "sidc": "S*G*UCAW--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13076,6 +15193,7 @@
   {
     "sidc": "S*G*UCAWA-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13088,6 +15206,7 @@
   {
     "sidc": "S*G*UCAWH-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13100,6 +15219,7 @@
   {
     "sidc": "S*G*UCAWL-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13112,6 +15232,7 @@
   {
     "sidc": "S*G*UCAWM-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13124,6 +15245,7 @@
   {
     "sidc": "S*G*UCAWR-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13136,6 +15258,7 @@
   {
     "sidc": "S*G*UCAWS-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13148,6 +15271,7 @@
   {
     "sidc": "S*G*UCAWW-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13160,6 +15284,7 @@
   {
     "sidc": "S*G*UCAWWR*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13172,6 +15297,7 @@
   {
     "sidc": "S*G*UCD---*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13184,6 +15310,7 @@
   {
     "sidc": "S*G*UCDC--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13197,6 +15324,7 @@
   {
     "sidc": "S*G*UCDG--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13210,6 +15338,7 @@
   {
     "sidc": "S*G*UCDH--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13223,6 +15352,7 @@
   {
     "sidc": "S*G*UCDHH-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13237,6 +15367,7 @@
   {
     "sidc": "S*G*UCDHP-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13251,6 +15382,7 @@
   {
     "sidc": "S*G*UCDM--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13263,6 +15395,7 @@
   {
     "sidc": "S*G*UCDMH-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13275,6 +15408,7 @@
   {
     "sidc": "S*G*UCDML-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13287,6 +15421,7 @@
   {
     "sidc": "S*G*UCDMLA*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13300,6 +15435,7 @@
   {
     "sidc": "S*G*UCDMM-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13312,6 +15448,7 @@
   {
     "sidc": "S*G*UCDO--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13325,6 +15462,7 @@
   {
     "sidc": "S*G*UCDS--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13338,6 +15476,7 @@
   {
     "sidc": "S*G*UCDSC-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13352,6 +15491,7 @@
   {
     "sidc": "S*G*UCDSS-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13366,6 +15506,7 @@
   {
     "sidc": "S*G*UCDSV-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13380,6 +15521,7 @@
   {
     "sidc": "S*G*UCDT--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13393,6 +15535,7 @@
   {
     "sidc": "S*G*UCE---*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13405,6 +15548,7 @@
   {
     "sidc": "S*G*UCEC--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13417,6 +15561,7 @@
   {
     "sidc": "S*G*UCECA-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13429,6 +15574,7 @@
   {
     "sidc": "S*G*UCECC-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13441,6 +15587,7 @@
   {
     "sidc": "S*G*UCECH-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13453,6 +15600,7 @@
   {
     "sidc": "S*G*UCECL-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13465,6 +15613,7 @@
   {
     "sidc": "S*G*UCECM-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13477,6 +15626,7 @@
   {
     "sidc": "S*G*UCECO-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13489,6 +15639,7 @@
   {
     "sidc": "S*G*UCECR-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13501,6 +15652,7 @@
   {
     "sidc": "S*G*UCECS-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13513,6 +15665,7 @@
   {
     "sidc": "S*G*UCECT-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13525,6 +15678,7 @@
   {
     "sidc": "S*G*UCECW-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13537,6 +15691,7 @@
   {
     "sidc": "S*G*UCEN--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13549,6 +15704,7 @@
   {
     "sidc": "S*G*UCENN-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13562,6 +15718,7 @@
   {
     "sidc": "S*G*UCF---*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13574,6 +15731,7 @@
   {
     "sidc": "S*G*UCFH--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13587,6 +15745,7 @@
   {
     "sidc": "S*G*UCFHA-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13601,6 +15760,7 @@
   {
     "sidc": "S*G*UCFHC-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13615,6 +15775,7 @@
   {
     "sidc": "S*G*UCFHE-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13629,6 +15790,7 @@
   {
     "sidc": "S*G*UCFHH-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13643,6 +15805,7 @@
   {
     "sidc": "S*G*UCFHL-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13657,6 +15820,7 @@
   {
     "sidc": "S*G*UCFHM-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13671,6 +15835,7 @@
   {
     "sidc": "S*G*UCFHO-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13685,6 +15850,7 @@
   {
     "sidc": "S*G*UCFHS-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13699,6 +15865,7 @@
   {
     "sidc": "S*G*UCFHX-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13713,6 +15880,7 @@
   {
     "sidc": "S*G*UCFM--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13726,6 +15894,7 @@
   {
     "sidc": "S*G*UCFML-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13739,6 +15908,7 @@
   {
     "sidc": "S*G*UCFMS-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13752,6 +15922,7 @@
   {
     "sidc": "S*G*UCFMT-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13765,6 +15936,7 @@
   {
     "sidc": "S*G*UCFMTA*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13779,6 +15951,7 @@
   {
     "sidc": "S*G*UCFMTC*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13793,6 +15966,7 @@
   {
     "sidc": "S*G*UCFMTO*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13807,6 +15981,7 @@
   {
     "sidc": "S*G*UCFMTS*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13821,6 +15996,7 @@
   {
     "sidc": "S*G*UCFMW-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13835,6 +16011,7 @@
   {
     "sidc": "S*G*UCFO--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13848,6 +16025,7 @@
   {
     "sidc": "S*G*UCFOA-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13861,6 +16039,7 @@
   {
     "sidc": "S*G*UCFOL-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13874,6 +16053,7 @@
   {
     "sidc": "S*G*UCFOO-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13887,6 +16067,7 @@
   {
     "sidc": "S*G*UCFOS-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13900,6 +16081,7 @@
   {
     "sidc": "S*G*UCFR--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13913,6 +16095,7 @@
   {
     "sidc": "S*G*UCFRM-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13926,6 +16109,7 @@
   {
     "sidc": "S*G*UCFRMR*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13940,6 +16124,7 @@
   {
     "sidc": "S*G*UCFRMS*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13954,6 +16139,7 @@
   {
     "sidc": "S*G*UCFRMT*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13968,6 +16154,7 @@
   {
     "sidc": "S*G*UCFRS-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13981,6 +16168,7 @@
   {
     "sidc": "S*G*UCFRSR*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -13995,6 +16183,7 @@
   {
     "sidc": "S*G*UCFRSS*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14009,6 +16198,7 @@
   {
     "sidc": "S*G*UCFRST*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14023,6 +16213,7 @@
   {
     "sidc": "S*G*UCFS--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14036,6 +16227,7 @@
   {
     "sidc": "S*G*UCFSA-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14050,6 +16242,7 @@
   {
     "sidc": "S*G*UCFSL-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14064,6 +16257,7 @@
   {
     "sidc": "S*G*UCFSO-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14078,6 +16272,7 @@
   {
     "sidc": "S*G*UCFSS-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14092,6 +16287,7 @@
   {
     "sidc": "S*G*UCFT--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14105,6 +16301,7 @@
   {
     "sidc": "S*G*UCFTA-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14119,6 +16316,7 @@
   {
     "sidc": "S*G*UCFTC-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14133,6 +16331,7 @@
   {
     "sidc": "S*G*UCFTCD*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14147,6 +16346,7 @@
   {
     "sidc": "S*G*UCFTCM*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14161,6 +16361,7 @@
   {
     "sidc": "S*G*UCFTF-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14175,6 +16376,7 @@
   {
     "sidc": "S*G*UCFTR-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14189,6 +16391,7 @@
   {
     "sidc": "S*G*UCFTS-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14203,6 +16406,7 @@
   {
     "sidc": "S*G*UCI---*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14215,6 +16419,7 @@
   {
     "sidc": "S*G*UCIA--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14227,6 +16432,7 @@
   {
     "sidc": "S*G*UCIC--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14239,6 +16445,7 @@
   {
     "sidc": "S*G*UCII--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14251,6 +16458,7 @@
   {
     "sidc": "S*G*UCIL--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14263,6 +16471,7 @@
   {
     "sidc": "S*G*UCIM--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14275,6 +16484,7 @@
   {
     "sidc": "S*G*UCIN--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14287,6 +16497,7 @@
   {
     "sidc": "S*G*UCIO--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14299,6 +16510,7 @@
   {
     "sidc": "S*G*UCIS--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14311,6 +16523,7 @@
   {
     "sidc": "S*G*UCIZ--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14323,6 +16536,7 @@
   {
     "sidc": "S*G*UCM---*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14335,6 +16549,7 @@
   {
     "sidc": "S*G*UCMS--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14347,6 +16562,7 @@
   {
     "sidc": "S*G*UCMT--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14359,6 +16575,7 @@
   {
     "sidc": "S*G*UCR---*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14371,6 +16588,7 @@
   {
     "sidc": "S*G*UCRA--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14383,6 +16601,7 @@
   {
     "sidc": "S*G*UCRC--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14395,6 +16614,7 @@
   {
     "sidc": "S*G*UCRH--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14407,6 +16627,7 @@
   {
     "sidc": "S*G*UCRL--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14419,6 +16640,7 @@
   {
     "sidc": "S*G*UCRO--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14431,6 +16653,7 @@
   {
     "sidc": "S*G*UCRR--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14443,6 +16666,7 @@
   {
     "sidc": "S*G*UCRRD-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14455,6 +16679,7 @@
   {
     "sidc": "S*G*UCRRF-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14467,6 +16692,7 @@
   {
     "sidc": "S*G*UCRRL-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14479,6 +16705,7 @@
   {
     "sidc": "S*G*UCRS--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14491,6 +16718,7 @@
   {
     "sidc": "S*G*UCRV--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14503,6 +16731,7 @@
   {
     "sidc": "S*G*UCRVA-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14515,6 +16744,7 @@
   {
     "sidc": "S*G*UCRVG-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14527,6 +16757,7 @@
   {
     "sidc": "S*G*UCRVM-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14539,6 +16770,7 @@
   {
     "sidc": "S*G*UCRVO-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14551,6 +16783,7 @@
   {
     "sidc": "S*G*UCRX--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14563,6 +16796,7 @@
   {
     "sidc": "S*G*UCS---*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14575,6 +16809,7 @@
   {
     "sidc": "S*G*UCSA--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14588,6 +16823,7 @@
   {
     "sidc": "S*G*UCSG--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14601,6 +16837,7 @@
   {
     "sidc": "S*G*UCSGA-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14614,6 +16851,7 @@
   {
     "sidc": "S*G*UCSGD-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14627,6 +16865,7 @@
   {
     "sidc": "S*G*UCSGM-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14640,6 +16879,7 @@
   {
     "sidc": "S*G*UCSM--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14653,6 +16893,7 @@
   {
     "sidc": "S*G*UCSR--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14666,6 +16907,7 @@
   {
     "sidc": "S*G*UCSW--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14679,6 +16921,7 @@
   {
     "sidc": "S*G*UCV---*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14691,6 +16934,7 @@
   {
     "sidc": "S*G*UCVC--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14704,6 +16948,7 @@
   {
     "sidc": "S*G*UCVF--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14717,6 +16962,7 @@
   {
     "sidc": "S*G*UCVFA-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14730,6 +16976,7 @@
   {
     "sidc": "S*G*UCVFR-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14743,6 +16990,7 @@
   {
     "sidc": "S*G*UCVFU-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14756,6 +17004,7 @@
   {
     "sidc": "S*G*UCVR--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14769,6 +17018,7 @@
   {
     "sidc": "S*G*UCVRA-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14782,6 +17032,7 @@
   {
     "sidc": "S*G*UCVRM-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14795,6 +17046,7 @@
   {
     "sidc": "S*G*UCVRS-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14808,6 +17060,7 @@
   {
     "sidc": "S*G*UCVRU-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14821,6 +17074,7 @@
   {
     "sidc": "S*G*UCVRUC*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14834,6 +17088,7 @@
   {
     "sidc": "S*G*UCVRUE*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14847,6 +17102,7 @@
   {
     "sidc": "S*G*UCVRUH*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14860,6 +17116,7 @@
   {
     "sidc": "S*G*UCVRUL*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14873,6 +17130,7 @@
   {
     "sidc": "S*G*UCVRUM*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14886,6 +17144,7 @@
   {
     "sidc": "S*G*UCVRW-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14899,6 +17158,7 @@
   {
     "sidc": "S*G*UCVS--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14912,6 +17172,7 @@
   {
     "sidc": "S*G*UCVU--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14925,6 +17186,7 @@
   {
     "sidc": "S*G*UCVUF-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14938,6 +17200,7 @@
   {
     "sidc": "S*G*UCVUR-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14951,6 +17214,7 @@
   {
     "sidc": "S*G*UCVV--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14964,6 +17228,7 @@
   {
     "sidc": "S*G*UH----*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14975,6 +17240,7 @@
   {
     "sidc": "S*G*US----*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14986,6 +17252,7 @@
   {
     "sidc": "S*G*USA---*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -14998,6 +17265,7 @@
   {
     "sidc": "S*G*USAC--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15010,6 +17278,7 @@
   {
     "sidc": "S*G*USAF--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15023,6 +17292,7 @@
   {
     "sidc": "S*G*USAFC-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15036,6 +17306,7 @@
   {
     "sidc": "S*G*USAFT-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15049,6 +17320,7 @@
   {
     "sidc": "S*G*USAJ--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15062,6 +17334,7 @@
   {
     "sidc": "S*G*USAJC-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15075,6 +17348,7 @@
   {
     "sidc": "S*G*USAJT-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15088,6 +17362,7 @@
   {
     "sidc": "S*G*USAL--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15101,6 +17376,7 @@
   {
     "sidc": "S*G*USALC-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15114,6 +17390,7 @@
   {
     "sidc": "S*G*USALT-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15127,6 +17404,7 @@
   {
     "sidc": "S*G*USAM--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15140,6 +17418,7 @@
   {
     "sidc": "S*G*USAMC-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15153,6 +17432,7 @@
   {
     "sidc": "S*G*USAMT-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15166,6 +17446,7 @@
   {
     "sidc": "S*G*USAO--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15179,6 +17460,7 @@
   {
     "sidc": "S*G*USAOC-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15192,6 +17474,7 @@
   {
     "sidc": "S*G*USAOT-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15205,6 +17488,7 @@
   {
     "sidc": "S*G*USAP--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15218,6 +17502,7 @@
   {
     "sidc": "S*G*USAPB-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15231,6 +17516,7 @@
   {
     "sidc": "S*G*USAPBC*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15244,6 +17530,7 @@
   {
     "sidc": "S*G*USAPBT*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15257,6 +17544,7 @@
   {
     "sidc": "S*G*USAPC-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15270,6 +17558,7 @@
   {
     "sidc": "S*G*USAPM-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15283,6 +17572,7 @@
   {
     "sidc": "S*G*USAPMC*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15296,6 +17586,7 @@
   {
     "sidc": "S*G*USAPMT*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15309,6 +17600,7 @@
   {
     "sidc": "S*G*USAPT-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15322,6 +17614,7 @@
   {
     "sidc": "S*G*USAQ--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15335,6 +17628,7 @@
   {
     "sidc": "S*G*USAQC-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15348,6 +17642,7 @@
   {
     "sidc": "S*G*USAQT-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15361,6 +17656,7 @@
   {
     "sidc": "S*G*USAR--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15374,6 +17670,7 @@
   {
     "sidc": "S*G*USARC-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15387,6 +17684,7 @@
   {
     "sidc": "S*G*USART-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15400,6 +17698,7 @@
   {
     "sidc": "S*G*USAS--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15413,6 +17712,7 @@
   {
     "sidc": "S*G*USASC-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15426,6 +17726,7 @@
   {
     "sidc": "S*G*USAST-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15439,6 +17740,7 @@
   {
     "sidc": "S*G*USAT--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15451,6 +17753,7 @@
   {
     "sidc": "S*G*USAW--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15464,6 +17767,7 @@
   {
     "sidc": "S*G*USAWC-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15477,6 +17781,7 @@
   {
     "sidc": "S*G*USAWT-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15490,6 +17795,7 @@
   {
     "sidc": "S*G*USAX--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15503,6 +17809,7 @@
   {
     "sidc": "S*G*USAXC-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15516,6 +17823,7 @@
   {
     "sidc": "S*G*USAXT-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15529,6 +17837,7 @@
   {
     "sidc": "S*G*USM---*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15541,6 +17850,7 @@
   {
     "sidc": "S*G*USMC--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15553,6 +17863,7 @@
   {
     "sidc": "S*G*USMD--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15565,6 +17876,7 @@
   {
     "sidc": "S*G*USMDC-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15577,6 +17889,7 @@
   {
     "sidc": "S*G*USMDT-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15589,6 +17902,7 @@
   {
     "sidc": "S*G*USMM--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15601,6 +17915,7 @@
   {
     "sidc": "S*G*USMMC-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15613,6 +17928,7 @@
   {
     "sidc": "S*G*USMMT-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15625,6 +17941,7 @@
   {
     "sidc": "S*G*USMP--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15637,6 +17954,7 @@
   {
     "sidc": "S*G*USMPC-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15649,6 +17967,7 @@
   {
     "sidc": "S*G*USMPT-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15661,6 +17980,7 @@
   {
     "sidc": "S*G*USMT--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15673,6 +17993,7 @@
   {
     "sidc": "S*G*USMV--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15685,6 +18006,7 @@
   {
     "sidc": "S*G*USMVC-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15697,6 +18019,7 @@
   {
     "sidc": "S*G*USMVT-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15709,6 +18032,7 @@
   {
     "sidc": "S*G*USS---*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15721,6 +18045,7 @@
   {
     "sidc": "S*G*USS1--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15733,6 +18058,7 @@
   {
     "sidc": "S*G*USS1C-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15745,6 +18071,7 @@
   {
     "sidc": "S*G*USS1T-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15757,6 +18084,7 @@
   {
     "sidc": "S*G*USS2--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15769,6 +18097,7 @@
   {
     "sidc": "S*G*USS2C-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15781,6 +18110,7 @@
   {
     "sidc": "S*G*USS2T-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15793,6 +18123,7 @@
   {
     "sidc": "S*G*USS3--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15805,6 +18136,7 @@
   {
     "sidc": "S*G*USS3A-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15817,6 +18149,7 @@
   {
     "sidc": "S*G*USS3AC*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15829,6 +18162,7 @@
   {
     "sidc": "S*G*USS3AT*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15841,6 +18175,7 @@
   {
     "sidc": "S*G*USS3C-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15853,6 +18188,7 @@
   {
     "sidc": "S*G*USS3T-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15865,6 +18201,7 @@
   {
     "sidc": "S*G*USS4--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15877,6 +18214,7 @@
   {
     "sidc": "S*G*USS4C-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15889,6 +18227,7 @@
   {
     "sidc": "S*G*USS4T-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15901,6 +18240,7 @@
   {
     "sidc": "S*G*USS5--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15913,6 +18253,7 @@
   {
     "sidc": "S*G*USS5C-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15925,6 +18266,7 @@
   {
     "sidc": "S*G*USS5T-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15937,6 +18279,7 @@
   {
     "sidc": "S*G*USS6--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15949,6 +18292,7 @@
   {
     "sidc": "S*G*USS6C-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15961,6 +18305,7 @@
   {
     "sidc": "S*G*USS6T-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15973,6 +18318,7 @@
   {
     "sidc": "S*G*USS7--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15985,6 +18331,7 @@
   {
     "sidc": "S*G*USS7C-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -15997,6 +18344,7 @@
   {
     "sidc": "S*G*USS7T-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16009,6 +18357,7 @@
   {
     "sidc": "S*G*USS8--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16021,6 +18370,7 @@
   {
     "sidc": "S*G*USS8C-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16033,6 +18383,7 @@
   {
     "sidc": "S*G*USS8T-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16045,6 +18396,7 @@
   {
     "sidc": "S*G*USS9--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16057,6 +18409,7 @@
   {
     "sidc": "S*G*USS9C-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16069,6 +18422,7 @@
   {
     "sidc": "S*G*USS9T-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16081,6 +18435,7 @@
   {
     "sidc": "S*G*USSC--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16093,6 +18448,7 @@
   {
     "sidc": "S*G*USSL--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16105,6 +18461,7 @@
   {
     "sidc": "S*G*USSLC-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16117,6 +18474,7 @@
   {
     "sidc": "S*G*USSLT-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16129,6 +18487,7 @@
   {
     "sidc": "S*G*USST--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16141,6 +18500,7 @@
   {
     "sidc": "S*G*USSW--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16153,6 +18513,7 @@
   {
     "sidc": "S*G*USSWC-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16165,6 +18526,7 @@
   {
     "sidc": "S*G*USSWP-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16177,6 +18539,7 @@
   {
     "sidc": "S*G*USSWPC*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16189,6 +18552,7 @@
   {
     "sidc": "S*G*USSWPT*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16201,6 +18565,7 @@
   {
     "sidc": "S*G*USSWT-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16213,6 +18578,7 @@
   {
     "sidc": "S*G*USSX--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16225,6 +18591,7 @@
   {
     "sidc": "S*G*USSXC-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16237,6 +18604,7 @@
   {
     "sidc": "S*G*USSXT-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16249,6 +18617,7 @@
   {
     "sidc": "S*G*UST---*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16261,6 +18630,7 @@
   {
     "sidc": "S*G*USTA--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16274,6 +18644,7 @@
   {
     "sidc": "S*G*USTAC-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16287,6 +18658,7 @@
   {
     "sidc": "S*G*USTAT-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16300,6 +18672,7 @@
   {
     "sidc": "S*G*USTC--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16312,6 +18685,7 @@
   {
     "sidc": "S*G*USTI--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16325,6 +18699,7 @@
   {
     "sidc": "S*G*USTIC-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16338,6 +18713,7 @@
   {
     "sidc": "S*G*USTIT-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16351,6 +18727,7 @@
   {
     "sidc": "S*G*USTM--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16364,6 +18741,7 @@
   {
     "sidc": "S*G*USTMC-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16378,6 +18756,7 @@
   {
     "sidc": "S*G*USTMT-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16392,6 +18771,7 @@
   {
     "sidc": "S*G*USTR--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16405,6 +18785,7 @@
   {
     "sidc": "S*G*USTRC-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16418,6 +18799,7 @@
   {
     "sidc": "S*G*USTRT-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16431,6 +18813,7 @@
   {
     "sidc": "S*G*USTS--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16444,6 +18827,7 @@
   {
     "sidc": "S*G*USTSC-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16457,6 +18841,7 @@
   {
     "sidc": "S*G*USTST-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16470,6 +18855,7 @@
   {
     "sidc": "S*G*USTT--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16482,6 +18868,7 @@
   {
     "sidc": "S*G*USX---*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16494,6 +18881,7 @@
   {
     "sidc": "S*G*USXC--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16506,6 +18894,7 @@
   {
     "sidc": "S*G*USXE--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16519,6 +18908,7 @@
   {
     "sidc": "S*G*USXEC-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16532,6 +18922,7 @@
   {
     "sidc": "S*G*USXET-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16545,6 +18936,7 @@
   {
     "sidc": "S*G*USXH--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16557,6 +18949,7 @@
   {
     "sidc": "S*G*USXHC-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16569,6 +18962,7 @@
   {
     "sidc": "S*G*USXHT-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16581,6 +18975,7 @@
   {
     "sidc": "S*G*USXO--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16594,6 +18989,7 @@
   {
     "sidc": "S*G*USXOC-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16607,6 +19003,7 @@
   {
     "sidc": "S*G*USXOM-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16620,6 +19017,7 @@
   {
     "sidc": "S*G*USXOMC*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16633,6 +19031,7 @@
   {
     "sidc": "S*G*USXOMT*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16646,6 +19045,7 @@
   {
     "sidc": "S*G*USXOT-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16659,6 +19059,7 @@
   {
     "sidc": "S*G*USXR--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16671,6 +19072,7 @@
   {
     "sidc": "S*G*USXRC-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16683,6 +19085,7 @@
   {
     "sidc": "S*G*USXRT-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16695,6 +19098,7 @@
   {
     "sidc": "S*G*USXT--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16707,6 +19111,7 @@
   {
     "sidc": "S*G*UU----*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16718,6 +19123,7 @@
   {
     "sidc": "S*G*UUA---*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16729,6 +19135,7 @@
   {
     "sidc": "S*G*UUAB--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16741,6 +19148,7 @@
   {
     "sidc": "S*G*UUABR-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16754,6 +19162,7 @@
   {
     "sidc": "S*G*UUAC--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16766,6 +19175,7 @@
   {
     "sidc": "S*G*UUACC-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16779,6 +19189,7 @@
   {
     "sidc": "S*G*UUACCK*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16792,6 +19203,7 @@
   {
     "sidc": "S*G*UUACCM*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16805,6 +19217,7 @@
   {
     "sidc": "S*G*UUACR-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16817,6 +19230,7 @@
   {
     "sidc": "S*G*UUACRS*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16830,6 +19244,7 @@
   {
     "sidc": "S*G*UUACRW*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16843,6 +19258,7 @@
   {
     "sidc": "S*G*UUACS-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16856,6 +19272,7 @@
   {
     "sidc": "S*G*UUACSA*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16869,6 +19286,7 @@
   {
     "sidc": "S*G*UUACSM*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16882,6 +19300,7 @@
   {
     "sidc": "S*G*UUAD--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16894,6 +19313,7 @@
   {
     "sidc": "S*G*UUAN--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16906,6 +19326,7 @@
   {
     "sidc": "S*G*UUE---*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16918,6 +19339,7 @@
   {
     "sidc": "S*G*UUI---*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16930,6 +19352,7 @@
   {
     "sidc": "S*G*UUL---*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16942,6 +19365,7 @@
   {
     "sidc": "S*G*UULC--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16955,6 +19379,7 @@
   {
     "sidc": "S*G*UULD--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16968,6 +19393,7 @@
   {
     "sidc": "S*G*UULF--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16981,6 +19407,7 @@
   {
     "sidc": "S*G*UULM--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -16994,6 +19421,7 @@
   {
     "sidc": "S*G*UULS--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -17007,6 +19435,7 @@
   {
     "sidc": "S*G*UUM---*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -17019,6 +19448,7 @@
   {
     "sidc": "S*G*UUMA--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -17032,6 +19462,7 @@
   {
     "sidc": "S*G*UUMC--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -17045,6 +19476,7 @@
   {
     "sidc": "S*G*UUMJ--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -17058,6 +19490,7 @@
   {
     "sidc": "S*G*UUMMO-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -17072,6 +19505,7 @@
   {
     "sidc": "S*G*UUMO--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -17085,6 +19519,7 @@
   {
     "sidc": "S*G*UUMQ--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -17098,6 +19533,7 @@
   {
     "sidc": "S*G*UUMR--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -17111,6 +19547,7 @@
   {
     "sidc": "S*G*UUMRG-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -17124,6 +19561,7 @@
   {
     "sidc": "S*G*UUMRS-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -17138,6 +19576,7 @@
   {
     "sidc": "S*G*UUMRSS*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -17152,6 +19591,7 @@
   {
     "sidc": "S*G*UUMRX-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -17166,6 +19606,7 @@
   {
     "sidc": "S*G*UUMS--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -17179,6 +19620,7 @@
   {
     "sidc": "S*G*UUMSE-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -17193,6 +19635,7 @@
   {
     "sidc": "S*G*UUMSEA*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -17208,6 +19651,7 @@
   {
     "sidc": "S*G*UUMSEC*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -17223,6 +19667,7 @@
   {
     "sidc": "S*G*UUMSED*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -17238,6 +19683,7 @@
   {
     "sidc": "S*G*UUMSEI*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -17253,6 +19699,7 @@
   {
     "sidc": "S*G*UUMSEJ*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -17268,6 +19715,7 @@
   {
     "sidc": "S*G*UUMSET*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -17283,6 +19731,7 @@
   {
     "sidc": "S*G*UUMT--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -17296,6 +19745,7 @@
   {
     "sidc": "S*G*UUP---*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -17308,6 +19758,7 @@
   {
     "sidc": "S*G*UUS---*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -17320,6 +19771,7 @@
   {
     "sidc": "S*G*UUSA--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -17333,6 +19785,7 @@
   {
     "sidc": "S*G*UUSC--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -17346,6 +19799,7 @@
   {
     "sidc": "S*G*UUSCL-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -17359,6 +19813,7 @@
   {
     "sidc": "S*G*UUSF--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -17372,6 +19827,7 @@
   {
     "sidc": "S*G*UUSM--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -17385,6 +19841,7 @@
   {
     "sidc": "S*G*UUSML-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -17399,6 +19856,7 @@
   {
     "sidc": "S*G*UUSMN-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -17413,6 +19871,7 @@
   {
     "sidc": "S*G*UUSMS-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -17427,6 +19886,7 @@
   {
     "sidc": "S*G*UUSO--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -17440,6 +19900,7 @@
   {
     "sidc": "S*G*UUSR--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -17453,6 +19914,7 @@
   {
     "sidc": "S*G*UUSRS-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -17467,6 +19929,7 @@
   {
     "sidc": "S*G*UUSRT-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -17481,6 +19944,7 @@
   {
     "sidc": "S*G*UUSRW-*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -17495,6 +19959,7 @@
   {
     "sidc": "S*G*UUSS--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -17508,6 +19973,7 @@
   {
     "sidc": "S*G*UUSW--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -17521,6 +19987,7 @@
   {
     "sidc": "S*G*UUSX--*****",
     "class": "U",
+    "scope": "UNIT",
     "geometry": "Point",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
@@ -17534,7 +20001,9 @@
   {
     "sidc": "S*P*------*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SPACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SPACE TRACK"
@@ -17543,7 +20012,9 @@
   {
     "sidc": "S*P*L-----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SPACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SPACE TRACK",
@@ -17553,7 +20024,9 @@
   {
     "sidc": "S*P*S-----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SPACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SPACE TRACK",
@@ -17563,7 +20036,9 @@
   {
     "sidc": "S*P*T-----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SPACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SPACE TRACK",
@@ -17573,7 +20048,9 @@
   {
     "sidc": "S*P*V-----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SPACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SPACE TRACK",
@@ -17583,7 +20060,9 @@
   {
     "sidc": "S*S*------*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK"
@@ -17592,7 +20071,9 @@
   {
     "sidc": "S*S*C-----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -17602,7 +20083,9 @@
   {
     "sidc": "S*S*CA----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -17613,7 +20096,9 @@
   {
     "sidc": "S*S*CALA--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -17625,7 +20110,9 @@
   {
     "sidc": "S*S*CALC--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -17637,7 +20124,9 @@
   {
     "sidc": "S*S*CALS--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -17649,7 +20138,9 @@
   {
     "sidc": "S*S*CALSM-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -17661,7 +20152,9 @@
   {
     "sidc": "S*S*CALST-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -17673,7 +20166,9 @@
   {
     "sidc": "S*S*CD----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -17684,7 +20179,9 @@
   {
     "sidc": "S*S*CH----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -17695,7 +20192,9 @@
   {
     "sidc": "S*S*CL----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -17706,7 +20205,9 @@
   {
     "sidc": "S*S*CLBB--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -17718,7 +20219,9 @@
   {
     "sidc": "S*S*CLCC--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -17730,7 +20233,9 @@
   {
     "sidc": "S*S*CLCV--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -17742,7 +20247,9 @@
   {
     "sidc": "S*S*CLDD--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -17754,7 +20261,9 @@
   {
     "sidc": "S*S*CLFF--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -17766,7 +20275,9 @@
   {
     "sidc": "S*S*CLLL--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -17778,7 +20289,9 @@
   {
     "sidc": "S*S*CLLLAS*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -17791,7 +20304,9 @@
   {
     "sidc": "S*S*CLLLMI*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -17804,7 +20319,9 @@
   {
     "sidc": "S*S*CLLLSU*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -17817,7 +20334,9 @@
   {
     "sidc": "S*S*CM----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -17828,7 +20347,9 @@
   {
     "sidc": "S*S*CMMA--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -17840,7 +20361,9 @@
   {
     "sidc": "S*S*CMMH--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -17852,7 +20375,9 @@
   {
     "sidc": "S*S*CMML--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -17864,7 +20389,9 @@
   {
     "sidc": "S*S*CMMS--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -17876,7 +20403,9 @@
   {
     "sidc": "S*S*CP----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -17887,7 +20416,9 @@
   {
     "sidc": "S*S*CPSB--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -17899,7 +20430,9 @@
   {
     "sidc": "S*S*CPSU--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -17911,7 +20444,9 @@
   {
     "sidc": "S*S*CPSUG-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -17924,7 +20459,9 @@
   {
     "sidc": "S*S*CPSUM-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -17937,7 +20474,9 @@
   {
     "sidc": "S*S*CPSUT-*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -17950,7 +20489,9 @@
   {
     "sidc": "S*S*CU----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -17961,7 +20502,9 @@
   {
     "sidc": "S*S*CUM---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -17973,7 +20516,9 @@
   {
     "sidc": "S*S*CUN---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -17985,7 +20530,9 @@
   {
     "sidc": "S*S*CUR---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -17996,7 +20543,9 @@
   {
     "sidc": "S*S*CUS---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -18008,7 +20557,9 @@
   {
     "sidc": "S*S*G-----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -18019,7 +20570,9 @@
   {
     "sidc": "S*S*GC----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -18031,7 +20584,9 @@
   {
     "sidc": "S*S*GG----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -18043,7 +20598,9 @@
   {
     "sidc": "S*S*GT----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -18055,7 +20612,9 @@
   {
     "sidc": "S*S*GU----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -18067,7 +20626,9 @@
   {
     "sidc": "S*S*N-----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -18077,7 +20638,9 @@
   {
     "sidc": "S*S*NF----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -18088,7 +20651,9 @@
   {
     "sidc": "S*S*NH----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -18099,7 +20664,9 @@
   {
     "sidc": "S*S*NI----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -18110,7 +20677,9 @@
   {
     "sidc": "S*S*NM----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -18121,7 +20690,9 @@
   {
     "sidc": "S*S*NR----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -18132,7 +20703,9 @@
   {
     "sidc": "S*S*NS----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -18143,7 +20716,9 @@
   {
     "sidc": "S*S*O-----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -18153,7 +20728,9 @@
   {
     "sidc": "S*S*X-----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -18163,7 +20740,9 @@
   {
     "sidc": "S*S*XA----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -18174,7 +20753,9 @@
   {
     "sidc": "S*S*XAR---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -18186,7 +20767,9 @@
   {
     "sidc": "S*S*XAS---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -18198,7 +20781,9 @@
   {
     "sidc": "S*S*XF----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -18209,7 +20794,9 @@
   {
     "sidc": "S*S*XFDF--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -18221,7 +20808,9 @@
   {
     "sidc": "S*S*XFDR--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -18233,7 +20822,9 @@
   {
     "sidc": "S*S*XFTR--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -18245,7 +20836,9 @@
   {
     "sidc": "S*S*XH----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -18256,7 +20849,9 @@
   {
     "sidc": "S*S*XL----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -18267,7 +20862,9 @@
   {
     "sidc": "S*S*XM----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -18278,7 +20875,9 @@
   {
     "sidc": "S*S*XMC---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -18290,7 +20889,9 @@
   {
     "sidc": "S*S*XMF---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -18302,7 +20903,9 @@
   {
     "sidc": "S*S*XMH---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -18314,7 +20917,9 @@
   {
     "sidc": "S*S*XMO---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -18326,7 +20931,9 @@
   {
     "sidc": "S*S*XMP---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -18338,7 +20945,9 @@
   {
     "sidc": "S*S*XMR---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -18350,7 +20959,9 @@
   {
     "sidc": "S*S*XMTO--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -18362,7 +20973,9 @@
   {
     "sidc": "S*S*XMTU--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -18374,7 +20987,9 @@
   {
     "sidc": "S*S*XP----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -18385,7 +21000,9 @@
   {
     "sidc": "S*S*XR----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SEA SURFACE TRACK",
@@ -18396,7 +21013,9 @@
   {
     "sidc": "S*U*------*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK"
@@ -18405,7 +21024,9 @@
   {
     "sidc": "S*U*E-----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18415,7 +21036,9 @@
   {
     "sidc": "S*U*N-----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18425,7 +21048,9 @@
   {
     "sidc": "S*U*ND----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18436,7 +21061,9 @@
   {
     "sidc": "S*U*S-----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18446,7 +21073,9 @@
   {
     "sidc": "S*U*S1----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18456,7 +21085,9 @@
   {
     "sidc": "S*U*S2----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18466,7 +21097,9 @@
   {
     "sidc": "S*U*S3----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18476,7 +21109,9 @@
   {
     "sidc": "S*U*S4----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18486,7 +21121,9 @@
   {
     "sidc": "S*U*SB----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18497,7 +21134,9 @@
   {
     "sidc": "S*U*SC----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18508,7 +21147,9 @@
   {
     "sidc": "S*U*SCA---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18520,7 +21161,9 @@
   {
     "sidc": "S*U*SCB---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18532,7 +21175,9 @@
   {
     "sidc": "S*U*SCF---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18543,7 +21188,9 @@
   {
     "sidc": "S*U*SCG---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18555,7 +21202,9 @@
   {
     "sidc": "S*U*SCM---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18567,7 +21216,9 @@
   {
     "sidc": "S*U*SF----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18577,7 +21228,9 @@
   {
     "sidc": "S*U*SK----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18587,7 +21240,9 @@
   {
     "sidc": "S*U*SL----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18597,7 +21252,9 @@
   {
     "sidc": "S*U*SN----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18608,7 +21265,9 @@
   {
     "sidc": "S*U*SNA---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18620,7 +21279,9 @@
   {
     "sidc": "S*U*SNB---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18632,7 +21293,9 @@
   {
     "sidc": "S*U*SNF---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18643,7 +21306,9 @@
   {
     "sidc": "S*U*SNG---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18655,7 +21320,9 @@
   {
     "sidc": "S*U*SNM---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18667,7 +21334,9 @@
   {
     "sidc": "S*U*SO----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18678,7 +21347,9 @@
   {
     "sidc": "S*U*SOF---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18689,7 +21360,9 @@
   {
     "sidc": "S*U*SR----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18699,7 +21372,9 @@
   {
     "sidc": "S*U*SU----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18710,7 +21385,9 @@
   {
     "sidc": "S*U*SUM---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18722,7 +21399,9 @@
   {
     "sidc": "S*U*SUN---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18734,7 +21413,9 @@
   {
     "sidc": "S*U*SUS---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18746,7 +21427,9 @@
   {
     "sidc": "S*U*SX----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18756,7 +21439,9 @@
   {
     "sidc": "S*U*V-----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18766,7 +21451,9 @@
   {
     "sidc": "S*U*W-----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18776,7 +21463,9 @@
   {
     "sidc": "S*U*WD----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18786,7 +21475,9 @@
   {
     "sidc": "S*U*WDM---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18797,7 +21488,9 @@
   {
     "sidc": "S*U*WDMG--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18809,7 +21502,9 @@
   {
     "sidc": "S*U*WDMM--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18821,7 +21516,9 @@
   {
     "sidc": "S*U*WM----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18832,7 +21529,9 @@
   {
     "sidc": "S*U*WMA---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18844,7 +21543,9 @@
   {
     "sidc": "S*U*WMB---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18856,7 +21557,9 @@
   {
     "sidc": "S*U*WMBD--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18869,7 +21572,9 @@
   {
     "sidc": "S*U*WMC---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18881,7 +21586,9 @@
   {
     "sidc": "S*U*WMD---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18892,7 +21599,9 @@
   {
     "sidc": "S*U*WME---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18904,7 +21613,9 @@
   {
     "sidc": "S*U*WMF---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18915,7 +21626,9 @@
   {
     "sidc": "S*U*WMFC--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18927,7 +21640,9 @@
   {
     "sidc": "S*U*WMFD--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18938,7 +21653,9 @@
   {
     "sidc": "S*U*WMFE--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18950,7 +21667,9 @@
   {
     "sidc": "S*U*WMFO--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18962,7 +21681,9 @@
   {
     "sidc": "S*U*WMFR--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18974,7 +21695,9 @@
   {
     "sidc": "S*U*WMFX--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18986,7 +21709,9 @@
   {
     "sidc": "S*U*WMG---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -18997,7 +21722,9 @@
   {
     "sidc": "S*U*WMGC--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -19009,7 +21736,9 @@
   {
     "sidc": "S*U*WMGD--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -19020,7 +21749,9 @@
   {
     "sidc": "S*U*WMGE--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -19032,7 +21763,9 @@
   {
     "sidc": "S*U*WMGO--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -19044,7 +21777,9 @@
   {
     "sidc": "S*U*WMGR--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -19056,7 +21791,9 @@
   {
     "sidc": "S*U*WMGX--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -19068,7 +21805,9 @@
   {
     "sidc": "S*U*WMM---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -19079,7 +21818,9 @@
   {
     "sidc": "S*U*WMMC--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -19091,7 +21832,9 @@
   {
     "sidc": "S*U*WMMD--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -19102,7 +21845,9 @@
   {
     "sidc": "S*U*WMME--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -19114,7 +21859,9 @@
   {
     "sidc": "S*U*WMMO--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -19126,7 +21873,9 @@
   {
     "sidc": "S*U*WMMR--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -19138,7 +21887,9 @@
   {
     "sidc": "S*U*WMMX--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -19150,7 +21901,9 @@
   {
     "sidc": "S*U*WMN---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -19161,7 +21914,9 @@
   {
     "sidc": "S*U*WMO---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -19172,7 +21927,9 @@
   {
     "sidc": "S*U*WMOD--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -19183,7 +21940,9 @@
   {
     "sidc": "S*U*WMR---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -19195,7 +21954,9 @@
   {
     "sidc": "S*U*WMS---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -19207,7 +21968,9 @@
   {
     "sidc": "S*U*WMSD--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -19221,7 +21984,9 @@
   {
     "sidc": "S*U*WMSX--*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -19234,7 +21999,9 @@
   {
     "sidc": "S*U*WMX---*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -19245,7 +22012,9 @@
   {
     "sidc": "S*U*WT----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",
@@ -19256,7 +22025,9 @@
   {
     "sidc": "S*U*X-----*****",
     "class": "E",
+    "scope": "EQUIPMENT",
     "geometry": "Point",
+    "dimension": "SUBSURFACE",
     "hierarchy": [
       "WARFIGHTING SYMBOLS",
       "SUBSURFACE TRACK",

--- a/src/renderer/components/palette/FeatureList.js
+++ b/src/renderer/components/palette/FeatureList.js
@@ -10,7 +10,7 @@ const FeatureList = props => {
   const { t } = useTranslation()
   const list = React.useRef()
 
-  if (list.current && listItems) {
+  if (list && list.current) {
     list.current.resetAfterIndex(0, true)
     list.current.scrollToItem(0, 'start')
   }
@@ -18,7 +18,7 @@ const FeatureList = props => {
   const getItemSize = index => {
     const descriptor = listItems[index]
     const textLength = descriptor.name.length + descriptor.hierarchy.length
-    console.log('##length', textLength, descriptor.name + ' ' + descriptor.hierarchy)
+    // console.log('##length', textLength, descriptor.name + ' ' + descriptor.hierarchy)
     if (textLength <= 45) return 80
     if (textLength <= 65) return 100
     if (textLength <= 85) return 120

--- a/src/renderer/components/palette/FeatureList.js
+++ b/src/renderer/components/palette/FeatureList.js
@@ -2,9 +2,18 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { VariableSizeList } from 'react-window'
 import FeatureItem from './FeatureItem'
+import { Typography } from '@material-ui/core'
+import { useTranslation } from 'react-i18next'
 
 const FeatureList = props => {
   const { listItems, handleClick, height } = props
+  const { t } = useTranslation()
+  const list = React.useRef()
+
+  if (list.current && listItems) {
+    list.current.resetAfterIndex(0, true)
+    list.current.scrollToItem(0, 'start')
+  }
 
   const getItemSize = index => {
     const descriptor = listItems[index]
@@ -18,21 +27,22 @@ const FeatureList = props => {
   }
 
   return (
-
-    <VariableSizeList
-      itemCount={listItems.length}
-      itemSize={getItemSize}
-      itemData={listItems}
-      estimatedItemSize={90}
-      height={height}
-      width={'100%'}
-    >
-      {({ index, style }) => {
-        const descriptor = listItems[index]
-        return <div style={style}><FeatureItem {...descriptor} key={descriptor.sortKey} onClick={handleClick(descriptor)} /></div>
-      }}
-    </VariableSizeList>
-
+    listItems && listItems.length
+      ? <VariableSizeList
+        itemCount={listItems.length}
+        itemSize={getItemSize}
+        itemData={listItems}
+        estimatedItemSize={90}
+        height={height}
+        width={'100%'}
+        ref={list}
+      >
+        {({ index, style }) => {
+          const descriptor = listItems[index]
+          return <div style={style}><FeatureItem {...descriptor} key={descriptor.sortKey} onClick={handleClick(descriptor)} /></div>
+        }}
+      </VariableSizeList>
+      : <Typography variant='body2'>{t('palette.featureList.noResults')}</Typography>
   )
 }
 

--- a/src/renderer/components/palette/FeatureList.js
+++ b/src/renderer/components/palette/FeatureList.js
@@ -8,12 +8,12 @@ import { useTranslation } from 'react-i18next'
 const FeatureList = props => {
   const { listItems, handleClick, height } = props
   const { t } = useTranslation()
-  const list = React.useRef()
 
-  if (list && list.current) {
-    list.current.resetAfterIndex(0, true)
-    list.current.scrollToItem(0, 'start')
-  }
+  const list = React.useCallback(element => {
+    if (!element) return
+    element.resetAfterIndex(0, true)
+    element.scrollToItem(0, 'start')
+  })
 
   const getItemSize = index => {
     const descriptor = listItems[index]

--- a/src/renderer/components/palette/FeatureList.js
+++ b/src/renderer/components/palette/FeatureList.js
@@ -12,7 +12,7 @@ const FeatureList = props => {
   const list = React.useCallback(element => {
     if (!element) return
     element.resetAfterIndex(0, true)
-    element.scrollToItem(0, 'start')
+    // element.scrollToItem(0, 'start')
   })
 
   const getItemSize = index => {

--- a/src/renderer/components/palette/FeatureList.js
+++ b/src/renderer/components/palette/FeatureList.js
@@ -1,0 +1,45 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { VariableSizeList } from 'react-window'
+import FeatureItem from './FeatureItem'
+
+const FeatureList = props => {
+  const { listItems, handleClick, height } = props
+
+  const getItemSize = index => {
+    const descriptor = listItems[index]
+    const textLength = descriptor.name.length + descriptor.hierarchy.length
+    console.log('##length', textLength, descriptor.name + ' ' + descriptor.hierarchy)
+    if (textLength <= 45) return 80
+    if (textLength <= 65) return 100
+    if (textLength <= 85) return 120
+    if (textLength <= 105) return 140
+    return 160
+  }
+
+  return (
+
+    <VariableSizeList
+      itemCount={listItems.length}
+      itemSize={getItemSize}
+      itemData={listItems}
+      estimatedItemSize={90}
+      height={height}
+      width={'100%'}
+    >
+      {({ index, style }) => {
+        const descriptor = listItems[index]
+        return <div style={style}><FeatureItem {...descriptor} key={descriptor.sortKey} onClick={handleClick(descriptor)} /></div>
+      }}
+    </VariableSizeList>
+
+  )
+}
+
+FeatureList.propTypes = {
+  listItems: PropTypes.array,
+  height: PropTypes.number,
+  handleClick: PropTypes.func
+}
+
+export default FeatureList

--- a/src/renderer/components/palette/FeaturePalette.js
+++ b/src/renderer/components/palette/FeaturePalette.js
@@ -69,8 +69,7 @@ const FeaturePalette = (/* props */) => {
 
   React.useEffect(() => {
     const memento = preferences.get('paletteMemento')
-    const filter = memento.filter || DEFAULT_FILTER
-    const presets = memento.presets || DEFAULT_PRESETS
+    const { filter = DEFAULT_FILTER, presets = DEFAULT_PRESETS } = memento || {}
     setFilter(filter)
     setPresets(presets)
   }, [])

--- a/src/renderer/components/palette/FeaturePalette.js
+++ b/src/renderer/components/palette/FeaturePalette.js
@@ -70,9 +70,9 @@ const FeaturePalette = (/* props */) => {
 
   React.useEffect(() => {
     const memento = preferences.get('paletteMemento')
-    let { filter, presets } = memento
-    if (!filter) filter = DEFAULT_FILTER
-    if (!presets) presets = DEFAULT_PRESETS
+    const { filter, presets } = (memento && Object.entries(memento).lenght > 0)
+      ? memento
+      : { filter: DEFAULT_FILTER, presets: DEFAULT_PRESETS }
     setFilter(filter)
     setPresets(presets)
   }, [])

--- a/src/renderer/components/palette/FeaturePalette.js
+++ b/src/renderer/components/palette/FeaturePalette.js
@@ -32,6 +32,7 @@ const useStyles = makeStyles((theme) => ({
   },
 
   list: {
+    margin: theme.spacing(1),
     display: 'flex',
     flexGrow: 1
   }
@@ -107,5 +108,4 @@ const FeaturePalette = (/* props */) => {
   )
 }
 
-// 
 export default FeaturePalette

--- a/src/renderer/components/palette/FeaturePalette.js
+++ b/src/renderer/components/palette/FeaturePalette.js
@@ -42,11 +42,9 @@ const FeaturePalette = (/* props */) => {
 
   const DEFAULT_FILTER = ''
   const DEFAULT_PRESETS = {
-    installation: null,
     status: 'P',
     hostility: 'F',
-    schema: 'S',
-    battleDimension: []
+    schema: 'S'
   }
 
   const classes = useStyles()
@@ -54,6 +52,7 @@ const FeaturePalette = (/* props */) => {
   const [height, setHeight] = React.useState(0)
   const [filter, setFilter] = React.useState(null)
   const [presets, setPresets] = React.useState(null)
+
 
   React.useEffect(() => {
     const hide = () => setShowing(false)
@@ -70,7 +69,8 @@ const FeaturePalette = (/* props */) => {
 
   React.useEffect(() => {
     const memento = preferences.get('paletteMemento')
-    const { filter = DEFAULT_FILTER, presets = DEFAULT_PRESETS } = memento || {}
+    const filter = memento.filter || DEFAULT_FILTER
+    const presets = memento.presets || DEFAULT_PRESETS
     setFilter(filter)
     setPresets(presets)
   }, [])

--- a/src/renderer/components/palette/FeaturePalette.js
+++ b/src/renderer/components/palette/FeaturePalette.js
@@ -70,9 +70,7 @@ const FeaturePalette = (/* props */) => {
 
   React.useEffect(() => {
     const memento = preferences.get('paletteMemento')
-    const { filter, presets } = (memento && Object.keys(memento).lenght !== 0)
-      ? memento
-      : { filter: DEFAULT_FILTER, presets: DEFAULT_PRESETS }
+    const { filter = DEFAULT_FILTER, presets = DEFAULT_PRESETS } = memento || {}
     setFilter(filter)
     setPresets(presets)
   }, [])

--- a/src/renderer/components/palette/FeaturePalette.js
+++ b/src/renderer/components/palette/FeaturePalette.js
@@ -40,17 +40,18 @@ const useStyles = makeStyles((theme) => ({
 
 const FeaturePalette = (/* props */) => {
 
-  const memento = preferences.get('paletteMemento')
+  // const memento = preferences.get('paletteMemento')
 
   const classes = useStyles()
   const [showing, setShowing] = React.useState(true)
   const [height, setHeight] = React.useState(0)
-  const [filter, setFilter] = React.useState(memento.filter || '')
-  const [presets, setPresets] = React.useState(memento.presets || {
+  const [filter, setFilter] = React.useState('')
+  const [presets, setPresets] = React.useState({
     installation: null,
     status: 'P',
     hostility: 'F',
-    schema: 'S'
+    schema: 'S',
+    battleDimension: []
   })
 
   React.useEffect(() => {
@@ -64,6 +65,14 @@ const FeaturePalette = (/* props */) => {
       evented.off('MAP_DRAW', hide)
       evented.off('MAP_DRAWEND', show)
     }
+  }, [])
+
+  React.useEffect(() => {
+    const memento = preferences.get('paletteMemento')
+    if (!memento) return
+    const { filter, presets } = memento
+    if (filter) setFilter(filter)
+    if (presets) setPresets(presets)
   }, [])
 
   const updateFilter = filter => {

--- a/src/renderer/components/palette/FeaturePalette.js
+++ b/src/renderer/components/palette/FeaturePalette.js
@@ -70,7 +70,7 @@ const FeaturePalette = (/* props */) => {
 
   React.useEffect(() => {
     const memento = preferences.get('paletteMemento')
-    const { filter, presets } = (memento && Object.entries(memento).lenght > 0)
+    const { filter, presets } = (memento && Object.keys(memento).lenght !== 0)
       ? memento
       : { filter: DEFAULT_FILTER, presets: DEFAULT_PRESETS }
     setFilter(filter)

--- a/src/renderer/components/palette/FeaturePalette.js
+++ b/src/renderer/components/palette/FeaturePalette.js
@@ -75,6 +75,12 @@ const FeaturePalette = (/* props */) => {
     if (presets) setPresets(presets)
   }, [])
 
+  const detectListHeigth = React.useCallback(element => {
+    if (!element) return
+    const currentHeight = element.getBoundingClientRect().height
+    if (currentHeight !== height) setHeight(currentHeight)
+  }, [])
+
   const updateFilter = filter => {
     setFilter(filter)
     const memento = preferences.get('paletteMemento') || {}
@@ -106,11 +112,7 @@ const FeaturePalette = (/* props */) => {
         <Presets value={presets} onChange={updatePresets}/>
       </div>
       <Search value={filter} onChange={updateFilter}/>
-      <div className={classes.list} ref={element => {
-        if (!element) return
-        const currentHeight = element.getBoundingClientRect().height
-        if (currentHeight !== height) setHeight(currentHeight)
-      }}>
+      <div className={classes.list} ref={detectListHeigth}>
         <FeatureList classes={classes} listItems={listItems} handleClick={itemSelected} height={height}/>
       </div>
     </Paper>

--- a/src/renderer/components/palette/Presets.js
+++ b/src/renderer/components/palette/Presets.js
@@ -63,6 +63,21 @@ const Presets = props => {
           <ToggleButton value="A">A</ToggleButton>
         </ToggleButtonGroup>
       </Tooltip>
+      <Tooltip title={t('palette.presets.schema')}>
+        <ToggleButtonGroup
+          size="small"
+          exclusive
+          className={classes.toggleContainer}
+          value={props.value.schema}
+          onChange={handleChange('schema')}
+        >
+          <ToggleButton value="S">U/E/I</ToggleButton>
+          <ToggleButton value="G">TG</ToggleButton>
+          <ToggleButton value="I">SIGINT</ToggleButton>
+          <ToggleButton value="O">Stability</ToggleButton>
+          <ToggleButton value="E">EMS</ToggleButton>
+        </ToggleButtonGroup>
+      </Tooltip>
     </span>
   )
 }
@@ -73,3 +88,24 @@ Presets.propTypes = {
 }
 
 export default Presets
+
+/*
+
+<Tooltip title={t('palette.presets.battleDimension')}>
+        <ToggleButtonGroup
+          size="small"
+          exclusive
+          className={classes.toggleContainer}
+          value={props.value.battleDimension}
+          onChange={handleChange('battleDimension')}
+        >
+          <ToggleButton value="P">P</ToggleButton>
+          <ToggleButton value="A">A</ToggleButton>
+          <ToggleButton value="G">G</ToggleButton>
+          <ToggleButton value="S">S</ToggleButton>
+          <ToggleButton value="U">U</ToggleButton>
+          <ToggleButton value="F">F</ToggleButton>
+        </ToggleButtonGroup>
+      </Tooltip>
+
+*/

--- a/src/renderer/components/palette/Presets.js
+++ b/src/renderer/components/palette/Presets.js
@@ -27,17 +27,6 @@ const Presets = props => {
 
   return (
     <span>
-      <Tooltip title={t('palette.presets.installation')}>
-        <ToggleButtonGroup
-          size="small"
-          exclusive
-          className={classes.toggleContainer}
-          value={props.value.installation}
-          onChange={handleChange('installation')}
-        >
-          <ToggleButton value="H">I</ToggleButton>
-        </ToggleButtonGroup>
-      </Tooltip>
       <Tooltip title={t('palette.presets.hostility')}>
         <ToggleButtonGroup
           size="small"
@@ -64,37 +53,6 @@ const Presets = props => {
           <ToggleButton value="A">A</ToggleButton>
         </ToggleButtonGroup>
       </Tooltip>
-      <Tooltip title={t('palette.presets.schema')}>
-        <ToggleButtonGroup
-          size="small"
-          exclusive
-          className={classes.toggleContainer}
-          value={props.value.schema}
-          onChange={handleChange('schema')}
-        >
-          <ToggleButton value="S">U/E/I</ToggleButton>
-          <ToggleButton value="G">TG</ToggleButton>
-          <ToggleButton value="I">SIGINT</ToggleButton>
-          <ToggleButton value="O">STBLTY</ToggleButton>
-          <ToggleButton value="E">EMS</ToggleButton>
-        </ToggleButtonGroup>
-      </Tooltip>
-      <Tooltip title={t('palette.presets.battleDimension')}>
-        <ToggleButtonGroup
-          size="small"
-          className={classes.toggleContainer}
-          value={props.value.battleDimension}
-          onChange={handleChange('battleDimension')}
-        >
-          <ToggleButton value="P">SPC</ToggleButton>
-          <ToggleButton value="A">AIR</ToggleButton>
-          <ToggleButton value="G">GND</ToggleButton>
-          <ToggleButton value="S">SRFC</ToggleButton>
-          <ToggleButton value="U">SUB</ToggleButton>
-          <ToggleButton value="F">SOF</ToggleButton>
-        </ToggleButtonGroup>
-      </Tooltip>
-
     </span>
   )
 }

--- a/src/renderer/components/palette/Presets.js
+++ b/src/renderer/components/palette/Presets.js
@@ -17,6 +17,7 @@ const useStyles = makeStyles((theme) => ({
 const Presets = props => {
   const classes = useStyles()
   const { t } = useTranslation()
+
   const handleChange = property => (_, value) => {
     if (!value && property !== 'installation') return
     const preset = { ...props.value }
@@ -74,10 +75,26 @@ const Presets = props => {
           <ToggleButton value="S">U/E/I</ToggleButton>
           <ToggleButton value="G">TG</ToggleButton>
           <ToggleButton value="I">SIGINT</ToggleButton>
-          <ToggleButton value="O">Stability</ToggleButton>
+          <ToggleButton value="O">STBLTY</ToggleButton>
           <ToggleButton value="E">EMS</ToggleButton>
         </ToggleButtonGroup>
       </Tooltip>
+      <Tooltip title={t('palette.presets.battleDimension')}>
+        <ToggleButtonGroup
+          size="small"
+          className={classes.toggleContainer}
+          value={props.value.battleDimension}
+          onChange={handleChange('battleDimension')}
+        >
+          <ToggleButton value="P">SPC</ToggleButton>
+          <ToggleButton value="A">AIR</ToggleButton>
+          <ToggleButton value="G">GND</ToggleButton>
+          <ToggleButton value="S">SRFC</ToggleButton>
+          <ToggleButton value="U">SUB</ToggleButton>
+          <ToggleButton value="F">SOF</ToggleButton>
+        </ToggleButtonGroup>
+      </Tooltip>
+
     </span>
   )
 }
@@ -88,24 +105,3 @@ Presets.propTypes = {
 }
 
 export default Presets
-
-/*
-
-<Tooltip title={t('palette.presets.battleDimension')}>
-        <ToggleButtonGroup
-          size="small"
-          exclusive
-          className={classes.toggleContainer}
-          value={props.value.battleDimension}
-          onChange={handleChange('battleDimension')}
-        >
-          <ToggleButton value="P">P</ToggleButton>
-          <ToggleButton value="A">A</ToggleButton>
-          <ToggleButton value="G">G</ToggleButton>
-          <ToggleButton value="S">S</ToggleButton>
-          <ToggleButton value="U">U</ToggleButton>
-          <ToggleButton value="F">F</ToggleButton>
-        </ToggleButtonGroup>
-      </Tooltip>
-
-*/

--- a/src/renderer/components/palette/Search.js
+++ b/src/renderer/components/palette/Search.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import { makeStyles } from '@material-ui/core/styles'
 import { InputBase } from '@material-ui/core'
 import { useTranslation } from 'react-i18next'
-import debounce from 'lodash.debounce'
 
 const useStyles = makeStyles((theme) => ({
   search: {
@@ -18,21 +17,27 @@ const useStyles = makeStyles((theme) => ({
   }
 }))
 
-const Search = props => {
+const Search = ({ initialValue, onChange, delay = 400 }) => {
   const classes = useStyles()
   const { t } = useTranslation()
+  const [value, setValue] = React.useState(initialValue)
+
+  React.useEffect(() => {
+    const timer = setTimeout(() => {
+      onChange(value)
+    }, delay)
+    return () => {
+      clearTimeout(timer)
+    }
+  }, [value])
+
+  const handleChange = ({ target }) => setValue(target.value)
+
   const handleKeyDown = event => {
     switch (event.key) {
-      case 'Escape': return props.onChange('')
+      case 'Escape': return onChange('')
     }
   }
-
-  const notifyParent = debounce(() => props.onChange(value), 400)
-
-  const [value, setValue] = React.useState(props.value)
-  React.useEffect(() => {
-    notifyParent()
-  }, [value])
 
   return (
     <InputBase
@@ -40,15 +45,16 @@ const Search = props => {
       placeholder={t('palette.search.placeholder')}
       autoFocus
       value={value}
-      onChange={({ target }) => setValue(target.value)}
+      onChange={handleChange}
       onKeyDown={handleKeyDown}
     />
   )
 }
 
 Search.propTypes = {
-  value: PropTypes.string.isRequired,
-  onChange: PropTypes.func.isRequired
+  initialValue: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  delay: PropTypes.number
 }
 
 export default Search

--- a/src/renderer/components/palette/Search.js
+++ b/src/renderer/components/palette/Search.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import { makeStyles } from '@material-ui/core/styles'
 import { InputBase } from '@material-ui/core'
 import { useTranslation } from 'react-i18next'
+import debounce from 'lodash.debounce'
 
 const useStyles = makeStyles((theme) => ({
   search: {
@@ -26,13 +27,20 @@ const Search = props => {
     }
   }
 
+  const notifyParent = debounce(() => props.onChange(value), 400)
+
+  const [value, setValue] = React.useState(props.value)
+  React.useEffect(() => {
+    notifyParent()
+  }, [value])
+
   return (
     <InputBase
       className={classes.search}
       placeholder={t('palette.search.placeholder')}
       autoFocus
-      value={props.value}
-      onChange={({ target }) => props.onChange(target.value)}
+      value={value}
+      onChange={({ target }) => setValue(target.value)}
       onKeyDown={handleKeyDown}
     />
   )

--- a/src/renderer/components/palette/Search.js
+++ b/src/renderer/components/palette/Search.js
@@ -17,21 +17,10 @@ const useStyles = makeStyles((theme) => ({
   }
 }))
 
-const Search = ({ initialValue, onChange, delay = 400 }) => {
+const Search = ({ initialValue, onChange }) => {
   const classes = useStyles()
   const { t } = useTranslation()
-  const [value, setValue] = React.useState(initialValue)
-
-  React.useEffect(() => {
-    const timer = setTimeout(() => {
-      onChange(value)
-    }, delay)
-    return () => {
-      clearTimeout(timer)
-    }
-  }, [value])
-
-  const handleChange = ({ target }) => setValue(target.value)
+  const handleChange = ({ target }) => onChange(target.value)
 
   const handleKeyDown = event => {
     switch (event.key) {
@@ -44,7 +33,7 @@ const Search = ({ initialValue, onChange, delay = 400 }) => {
       className={classes.search}
       placeholder={t('palette.search.placeholder')}
       autoFocus
-      value={value}
+      value={initialValue}
       onChange={handleChange}
       onKeyDown={handleKeyDown}
     />


### PR DESCRIPTION
This PR switches the symbol palette default from showing no symbols to showing all symbols. We use the power of [lunr](https://lunrjs.com) to do a full search in the symbol descriptions and (optional) tags.