### PR TITLE
feature attribution

### DIFF
--- a/src/i18n/de/web.json
+++ b/src/i18n/de/web.json
@@ -27,6 +27,7 @@
     "stepFinalize": "Benennen und Speichern",
     "descriptorUrl": "URL der Karte",
     "descriptorName": "Bezeichnung der Karte",
+    "attributions": "Namensnennungen",
     "xyzZoomOptions": "Minimale und maximale Zoomstufe",
     "unknownSource": "Kartentyp konnte anhand der URL nicht erkannt werden",
     "usePreview": "Benutzen Sie die Vorschau um die Karte zu überprüfen",

--- a/src/i18n/en/web.json
+++ b/src/i18n/en/web.json
@@ -27,6 +27,7 @@
     "stepFinalize": "Choose name and save",
     "descriptorUrl": "URL of the map",
     "descriptorName": "Name of the map",
+    "attributions": "Attributions",
     "xyzZoomOptions": "Minimum and maximum zoom level",
     "unknownSource": "Type of the map could no be detected by inspecting the URL",
     "usePreview": "Use the map preview to verify the basemap",

--- a/src/renderer/components/Activities.js
+++ b/src/renderer/components/Activities.js
@@ -1,11 +1,12 @@
 import React from 'react'
 import { makeStyles } from '@material-ui/core/styles'
 import Paper from '@material-ui/core/Paper'
-import Category from '@material-ui/icons/Category'
-import PermDataSettingIcon from '@material-ui/icons/PermDataSetting'
-import MapIcon from '@material-ui/icons/Map'
-import PhotoCameraIcon from '@material-ui/icons/PhotoCamera'
-import { LayersTriple, Undo, Redo, ContentCut, ContentCopy, ContentPaste } from 'mdi-material-ui'
+import Category from '@material-ui/icons/CategoryOutlined'
+import PermDataSettingIcon from '@material-ui/icons/PermDataSettingOutlined'
+import MapIcon from '@material-ui/icons/MapOutlined'
+import PhotoCameraIcon from '@material-ui/icons/PhotoCameraOutlined'
+// import InfoIcon from '@material-ui/icons/InfoOutlined'
+import { LayersTripleOutline, Undo, Redo, ContentCut, ContentCopy, ContentPaste } from 'mdi-material-ui'
 
 import ActivityBar from './ActivityBar'
 import BasemapPanel from './basemapPanel/BasemapPanel'
@@ -36,7 +37,7 @@ const initialActivities = (classes, t) => [
   {
     id: 'layers',
     type: 'activity',
-    icon: <LayersTriple/>,
+    icon: <LayersTripleOutline/>,
     panel: () => <LayerList/>,
     tooltip: t('activities.tooltips.layers')
   },

--- a/src/renderer/components/basemap/Name.js
+++ b/src/renderer/components/basemap/Name.js
@@ -5,10 +5,11 @@ import { Card, CardContent, FormControl, Input, InputLabel } from '@material-ui/
 import { useTranslation } from 'react-i18next'
 
 const Name = props => {
-  const { classes } = props
+  const { classes, merge } = props
   const { t } = useTranslation()
 
   const [name, setName] = React.useState(props.name)
+  const [attributions, setAttributions] = React.useState(props.attributions)
   const [isValid, setIsValid] = React.useState(false)
 
   React.useEffect(() => {
@@ -23,15 +24,28 @@ const Name = props => {
     setName(event.target.value)
   }
 
+  const handleAttributionsChanged = (event) => {
+    setAttributions(event.target.value)
+  }
+
   return (
     <Card variant="outlined">
       <CardContent>
         <div id="editName">
           <FormControl error={!isValid} fullWidth className={classes.formControl}>
-            <InputLabel htmlFor="descriptorName">{t('basemapManagement.descriptorName')}</InputLabel>
+            <InputLabel htmlFor="name">{t('basemapManagement.descriptorName')}</InputLabel>
             <Input id="name" name="name" defaultValue={name} autoFocus={true}
               onChange={handlePropertyChanged}
               onBlur={() => props.onNameReady(name)}
+            />
+          </FormControl>
+        </div>
+        <div id="editAttribution">
+          <FormControl fullWidth className={classes.formControl}>
+            <InputLabel htmlFor="attributions">{t('basemapManagement.attributions')}</InputLabel>
+            <Input id="attributions" name="attributions" defaultValue={attributions}
+              onChange={handleAttributionsChanged}
+              onBlur={() => merge('attributions', attributions)}
             />
           </FormControl>
         </div>
@@ -41,7 +55,9 @@ const Name = props => {
 }
 Name.propTypes = {
   classes: PropTypes.object,
-  name: PropTypes.string.isRequired,
+  name: PropTypes.string,
+  attributions: PropTypes.string,
+  merge: PropTypes.func,
   onValidation: PropTypes.func,
   onNameReady: PropTypes.func
 }

--- a/src/renderer/components/basemap/SourceDescriptorDetails.js
+++ b/src/renderer/components/basemap/SourceDescriptorDetails.js
@@ -129,6 +129,9 @@ const SourceDescriptorDetails = props => {
           classes={classes}
           // eslint-disable-next-line react/prop-types
           name={metadata.name}
+          // eslint-disable-next-line react/prop-types
+          attributions={options.attributions}
+          merge={mergeOptions}
           onValidation={setAllowNextStep}
           onNameReady={name => mergeMetadata('name', name)}
         />

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -12,3 +12,12 @@
   background-color: rgba(255,255,255,0.4);
   border-color: rgba(100,150,0,1);
 }
+
+.ol-attribution {
+  text-align: right;
+  font-family: Roboto;
+  font-size: small;
+  bottom: .5em;
+  right: .5em;
+  max-width: calc(100% - 1.3em);
+}

--- a/src/renderer/map/Map.js
+++ b/src/renderer/map/Map.js
@@ -6,7 +6,7 @@ import throttle from 'lodash.throttle'
 import * as ol from 'ol'
 import 'ol/ol.css'
 import { fromLonLat, toLonLat } from 'ol/proj'
-import { ScaleLine } from 'ol/control'
+import { Attribution, ScaleLine } from 'ol/control'
 import { defaults as defaultInteractions } from 'ol/interaction'
 import { Vector as VectorLayer } from 'ol/layer'
 import getGridLayerGroup from './grids/group'
@@ -56,10 +56,14 @@ const effect = props => () => {
     minWidth: 140
   })
 
+  const attribution = new Attribution({
+    collapsible: true
+  })
+
   const map = new ol.Map({
     view,
     target: id,
-    controls: [scaleLine],
+    controls: [scaleLine, attribution],
     layers: [basemapLayerGroup(), getGridLayerGroup()],
     interactions: defaultInteractions({
       doubleClickZoom: false

--- a/src/renderer/map/basemap/tileSources.js
+++ b/src/renderer/map/basemap/tileSources.js
@@ -15,7 +15,8 @@ const highDPI = DEVICE_PIXEL_RATIO > 1
 export const DEFAULT_SOURCE_DESCRIPTOR = Object.freeze({
   name: 'Open Street Map',
   type: 'OSM',
-  id: '708b7f83-12a2-4a8b-a49d-9f2683586bcf'
+  id: '708b7f83-12a2-4a8b-a49d-9f2683586bcf',
+  attributions: '<a href="openstreetmap.org">OpenStreetMap</a> contributors'
 })
 
 const wmsOptionsFromDescriptor = descriptor => {
@@ -43,6 +44,7 @@ const sources = {
     const wmtsOptions = optionsFromCapabilities(capabilities, descriptor.options)
     wmtsOptions.tilePixelRatio = (highDPI ? 2 : 1)
     wmtsOptions.crossOrigin = 'anonymous'
+    wmtsOptions.attributions = descriptor.options.attributions
     return new WMTS(wmtsOptions)
   },
   WMS: async descriptor => {


### PR DESCRIPTION
In order to follow the guidelines for the usage of publicly available map sources this PR introduces the attribution property for (base)map sources (see #371).

We also follow the commonly used place in the lower right corner of the map to show the attributions. ODIN allows multiple maps to be visible so the attributions auf all visible maps are combined:

<img width="399" alt="image" src="https://user-images.githubusercontent.com/38359572/103529362-d40a6500-4e85-11eb-92d7-19ff80861b9d.png">

Since attributions often require users to include links to the data sources we also allow http(s) links. These links are clickable but instead of opening them in ODIN we forward the requests to the system's default browser.

This may affect future features since forwarding is down by hijacking the ```will-navigate``` and ```new-window``` events of electron's webcontent and prevents their default behavior.