### PR TITLE
sanitized basemap attributions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@material-ui/icons": "^4.11.2",
         "@material-ui/lab": "^4.0.0-alpha.57",
         "archiver": "^5.2.0",
+        "dompurify": "^2.2.7",
         "dotenv": "^8.2.0",
         "electron-settings": "^3.2.0",
         "electron-updater": "^4.3.5",
@@ -1219,8 +1220,6 @@
         "debug": "^4.1.1",
         "env-paths": "^2.2.0",
         "fs-extra": "^8.1.0",
-        "global-agent": "^2.0.2",
-        "global-tunnel-ng": "^2.7.1",
         "got": "^9.6.0",
         "progress": "^2.0.3",
         "semver": "^6.2.0",
@@ -3168,7 +3167,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -4300,6 +4298,11 @@
       "dependencies": {
         "domelementtype": "1"
       }
+    },
+    "node_modules/dompurify": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.2.7.tgz",
+      "integrity": "sha512-jdtDffdGNY+C76jvodNTu9jt5yYj59vuTUyx+wXdzcSwAGTYZDAQkQ7Iwx9zcGrA4ixC1syU4H3RZROqRxokxg=="
     },
     "node_modules/domutils": {
       "version": "1.7.0",
@@ -12688,7 +12691,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -17336,6 +17338,11 @@
       "requires": {
         "domelementtype": "1"
       }
+    },
+    "dompurify": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.2.7.tgz",
+      "integrity": "sha512-jdtDffdGNY+C76jvodNTu9jt5yYj59vuTUyx+wXdzcSwAGTYZDAQkQ7Iwx9zcGrA4ixC1syU4H3RZROqRxokxg=="
     },
     "domutils": {
       "version": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.57",
     "archiver": "^5.2.0",
+    "dompurify": "^2.2.7",
     "dotenv": "^8.2.0",
     "electron-settings": "^3.2.0",
     "electron-updater": "^4.3.5",

--- a/src/renderer/components/basemap/Name.js
+++ b/src/renderer/components/basemap/Name.js
@@ -1,15 +1,23 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Card, CardContent, FormControl, Input, InputLabel } from '@material-ui/core'
-
+import DOMPurify from 'dompurify'
 import { useTranslation } from 'react-i18next'
+
+const SANITIZE_OPTIONS = {
+  ALLOWED_TAGS: ['a'],
+  ALLOWED_ATTR: ['href'],
+  ALLOW_DATA_ATTR: false
+}
 
 const Name = props => {
   const { classes, merge } = props
   const { t } = useTranslation()
 
   const [name, setName] = React.useState(props.name)
-  const [attributions, setAttributions] = React.useState(props.attributions)
+  const [attributions, setAttributions] = React.useState(
+    DOMPurify.sanitize(props.attributions, SANITIZE_OPTIONS)
+  )
   const [isValid, setIsValid] = React.useState(false)
 
   React.useEffect(() => {
@@ -26,6 +34,10 @@ const Name = props => {
 
   const handleAttributionsChanged = (event) => {
     setAttributions(event.target.value)
+  }
+
+  const saveAttributions = () => {
+    merge('attributions', DOMPurify.sanitize(attributions, SANITIZE_OPTIONS))
   }
 
   return (
@@ -45,7 +57,7 @@ const Name = props => {
             <InputLabel htmlFor="attributions">{t('basemapManagement.attributions')}</InputLabel>
             <Input id="attributions" name="attributions" defaultValue={attributions}
               onChange={handleAttributionsChanged}
-              onBlur={() => merge('attributions', attributions)}
+              onBlur={saveAttributions}
             />
           </FormControl>
         </div>


### PR DESCRIPTION
Since everything that is put into the attributions property of a basemap will get displayed by the OL attributions control it needs to get sanitized. This PR introduces the [DOMPurify library](https://github.com/cure53/DOMPurify) in order to limit attributions to a ```<a>``` tag with a single ```href``` attribute.