### PR TITLE
user influenceable styling for tactical symbols

### DIFF
--- a/src/i18n/de/web.json
+++ b/src/i18n/de/web.json
@@ -106,6 +106,8 @@
     },
     "simpleStatusModifier": "Vereinfachte Statusanzeige",
     "symbolSizeByEchelon": "Größenordnung beeinflusst Symbolgröße",
-    "symbolTextSize": "Textgröße bei Symbolen"
+    "symbolTextSize": "Textgröße für Symbole",
+    "labelTextSize": "Textgröße für Beschriftung",
+    "useBoldLabelText": "Text ist 'fett'"
   }
 }

--- a/src/i18n/de/web.json
+++ b/src/i18n/de/web.json
@@ -103,6 +103,7 @@
       "light": "hell",
       "medium": "mittel",
       "dark": "dunkel"
-    }
+    },
+    "simpleStatusModifier": "Vereinfachte Statusanzeige"
   }
 }

--- a/src/i18n/de/web.json
+++ b/src/i18n/de/web.json
@@ -104,6 +104,7 @@
       "medium": "mittel",
       "dark": "dunkel"
     },
-    "simpleStatusModifier": "Vereinfachte Statusanzeige"
+    "simpleStatusModifier": "Vereinfachte Statusanzeige",
+    "symbolSizeByEchelon": "Größenordnung beeinflusst Symbolgröße"
   }
 }

--- a/src/i18n/de/web.json
+++ b/src/i18n/de/web.json
@@ -97,6 +97,12 @@
   "preferences": {
     "name": "Einstellungen",
     "lineWidth": "Linienstärke",
-    "symbolSize": "Symbolgröße"
-  } 
+    "symbolSize": "Symbolgröße",
+    "scheme": {
+      "name": "Farbschema",
+      "light": "hell",
+      "medium": "mittel",
+      "dark": "dunkel"
+    }
+  }
 }

--- a/src/i18n/de/web.json
+++ b/src/i18n/de/web.json
@@ -105,6 +105,7 @@
       "dark": "dunkel"
     },
     "simpleStatusModifier": "Vereinfachte Statusanzeige",
-    "symbolSizeByEchelon": "Größenordnung beeinflusst Symbolgröße"
+    "symbolSizeByEchelon": "Größenordnung beeinflusst Symbolgröße",
+    "symbolTextSize": "Textgröße bei Symbolen"
   }
 }

--- a/src/i18n/de/web.json
+++ b/src/i18n/de/web.json
@@ -93,5 +93,10 @@
     "outline": "Umrandung",
     "border": "Rahmen",
     "rotation": "Drehung"
-  }
+  },
+  "preferences": {
+    "name": "Einstellungen",
+    "lineWidth": "Linienstärke",
+    "symbolSize": "Symbolgröße"
+  } 
 }

--- a/src/i18n/en/web.json
+++ b/src/i18n/en/web.json
@@ -93,5 +93,10 @@
     "outline": "Outline",
     "border": "Border",
     "rotation": "Rotation"
+  },
+  "preferences": {
+    "name": "Preferences",
+    "lineWidth": "line width",
+    "symbolSize": "symbol size"
   }
 }

--- a/src/i18n/en/web.json
+++ b/src/i18n/en/web.json
@@ -106,6 +106,8 @@
     },
     "simpleStatusModifier": "use simple status modifier",
     "symbolSizeByEchelon": "scale symbols with echelon",
-    "symbolTextSize": "fint size for symbols"
+    "symbolTextSize": "font size for symbols",
+    "labelTextSize": "font size for labels",
+    "useBoldLabelText": "label text is bold"
   }
 }

--- a/src/i18n/en/web.json
+++ b/src/i18n/en/web.json
@@ -104,6 +104,7 @@
       "medium": "medium",
       "dark": "dark"
     },
-    "simpleStatusModifier": "use simple status modifier"
+    "simpleStatusModifier": "use simple status modifier",
+    "symbolSizeByEchelon": "scale symbols with echelon"
   }
 }

--- a/src/i18n/en/web.json
+++ b/src/i18n/en/web.json
@@ -97,6 +97,12 @@
   "preferences": {
     "name": "Preferences",
     "lineWidth": "line width",
-    "symbolSize": "symbol size"
+    "symbolSize": "symbol size",
+    "scheme": {
+      "name": "color scheme",
+      "light": "light",
+      "medium": "medium",
+      "dark": "dark"
+    }
   }
 }

--- a/src/i18n/en/web.json
+++ b/src/i18n/en/web.json
@@ -103,6 +103,7 @@
       "light": "light",
       "medium": "medium",
       "dark": "dark"
-    }
+    },
+    "simpleStatusModifier": "use simple status modifier"
   }
 }

--- a/src/i18n/en/web.json
+++ b/src/i18n/en/web.json
@@ -105,6 +105,7 @@
       "dark": "dark"
     },
     "simpleStatusModifier": "use simple status modifier",
-    "symbolSizeByEchelon": "scale symbols with echelon"
+    "symbolSizeByEchelon": "scale symbols with echelon",
+    "symbolTextSize": "fint size for symbols"
   }
 }

--- a/src/renderer/components/Activities.js
+++ b/src/renderer/components/Activities.js
@@ -102,6 +102,10 @@ const initialActivities = (classes, t) => [
         ]}
         onChange={value => preferences.set('symbolSize', value)}
       />
+      <SwitchSetting defaultValue={preferences.get('symbolSizeByEchelon')}
+        onChange={value => preferences.set('symbolSizeByEchelon', value)}
+        label={t('preferences.symbolSizeByEchelon')}
+      />
       <SwitchSetting defaultValue={preferences.get('simpleStatusModifier')}
         onChange={value => preferences.set('simpleStatusModifier', value)}
         label={t('preferences.simpleStatusModifier')}

--- a/src/renderer/components/Activities.js
+++ b/src/renderer/components/Activities.js
@@ -6,6 +6,8 @@ import PermDataSettingIcon from '@material-ui/icons/PermDataSettingOutlined'
 import MapIcon from '@material-ui/icons/MapOutlined'
 import PhotoCameraIcon from '@material-ui/icons/PhotoCameraOutlined'
 import Button from '@material-ui/core/Button'
+import AddIcon from '@material-ui/icons/Add'
+import RemoveIcon from '@material-ui/icons/Remove'
 import { LayersTripleOutline, Undo, Redo, ContentCut, ContentCopy, ContentPaste } from 'mdi-material-ui'
 
 import ActivityBar from './ActivityBar'
@@ -14,6 +16,7 @@ import LayerList from './layerlist/LayerList'
 import FeaturePalette from './palette/FeaturePalette'
 import undo from '../undo'
 import evented from '../evented'
+import preferences from '../project/preferences'
 
 import { useTranslation } from 'react-i18next'
 
@@ -57,6 +60,27 @@ const initialActivities = (classes, t) => [
       <Button variant='outlined' fullWidth={true} style={{ marginBottom: '0.5em' }} onClick={() => evented.emit('MAP_MEASURE_LENGTH')}>{t('measure.length')}</Button>
       <Button variant='outlined' fullWidth={true} style={{ marginBottom: '0.5em' }} onClick={() => evented.emit('MAP_MEASURE_AREA')}>{t('measure.area')}</Button>
     </Paper>
+  },
+  {
+    id: 'incLineWidth',
+    type: 'action',
+    icon: <AddIcon />,
+    tooltip: t('activities.tooltips.undo'),
+    action: () => {
+      const current = preferences.get('lineWidth') || 3
+      preferences.set('lineWidth', current + 1)
+    }
+  },
+  {
+    id: 'decLineWidth',
+    type: 'action',
+    icon: <RemoveIcon />,
+    tooltip: t('activities.tooltips.undo'),
+    action: () => {
+      const current = (preferences.get('lineWidth') || 3)
+      if (current <= 3) return
+      preferences.set('lineWidth', current - 1)
+    }
   },
   {
     type: 'divider'

--- a/src/renderer/components/Activities.js
+++ b/src/renderer/components/Activities.js
@@ -6,14 +6,14 @@ import PermDataSettingIcon from '@material-ui/icons/PermDataSettingOutlined'
 import MapIcon from '@material-ui/icons/MapOutlined'
 import PhotoCameraIcon from '@material-ui/icons/PhotoCameraOutlined'
 import Button from '@material-ui/core/Button'
-import AddIcon from '@material-ui/icons/Add'
-import RemoveIcon from '@material-ui/icons/Remove'
+import SettingsIcon from '@material-ui/icons/Settings'
 import { LayersTripleOutline, Undo, Redo, ContentCut, ContentCopy, ContentPaste } from 'mdi-material-ui'
 
 import ActivityBar from './ActivityBar'
 import BasemapPanel from './basemapPanel/BasemapPanel'
 import LayerList from './layerlist/LayerList'
 import FeaturePalette from './palette/FeaturePalette'
+import SliderSettings from './settings/SliderSetting'
 import undo from '../undo'
 import evented from '../evented'
 import preferences from '../project/preferences'
@@ -62,25 +62,23 @@ const initialActivities = (classes, t) => [
     </Paper>
   },
   {
-    id: 'incLineWidth',
-    type: 'action',
-    icon: <AddIcon />,
-    tooltip: t('activities.tooltips.undo'),
-    action: () => {
-      const current = preferences.get('lineWidth') || 3
-      preferences.set('lineWidth', current + 1)
-    }
-  },
-  {
-    id: 'decLineWidth',
-    type: 'action',
-    icon: <RemoveIcon />,
-    tooltip: t('activities.tooltips.undo'),
-    action: () => {
-      const current = (preferences.get('lineWidth') || 3)
-      if (current <= 3) return
-      preferences.set('lineWidth', current - 1)
-    }
+    id: 'settings',
+    type: 'activity',
+    icon: <SettingsIcon />,
+    tooltip: t('activities.tooltips.tools'),
+    panel: () => <Paper className={classes.toolsPanel} elevation={6}>
+      <SliderSettings
+        caption='Überschrift'
+        defaultValue={preferences.get('lineWidth')}
+        marks={[
+          { label: 'S', value: 2 },
+          { label: 'M', value: 3 },
+          { label: 'L', value: 4 },
+          { label: 'XL', value: 5 }
+        ]}
+        onChange={value => preferences.set('lineWidth', value)}
+      />
+    </Paper>
   },
   {
     type: 'divider'

--- a/src/renderer/components/Activities.js
+++ b/src/renderer/components/Activities.js
@@ -70,46 +70,63 @@ const initialActivities = (classes, t) => [
     icon: <SettingsIcon />,
     tooltip: t('preferences.name'),
     panel: () => <Paper className={classes.toolsPanel} elevation={6}>
-      <SliderSetting
-        caption={t('preferences.scheme.name')}
-        defaultValue={ schemeToSliderValue(preferences.get('scheme')) }
-        marks={[
-          { label: t('preferences.scheme.light'), value: 0 },
-          { label: t('preferences.scheme.medium'), value: 50 },
-          { label: t('preferences.scheme.dark'), value: 100 }
-        ]}
-        onChange={value => preferences.set('scheme', sliderValueToScheme(value))}
-      />
-      <SliderSetting
-        caption={t('preferences.lineWidth')}
-        defaultValue={preferences.get('lineWidth')}
-        marks={[
-          { label: 'S', value: 2 },
-          { label: 'M', value: 3 },
-          { label: 'L', value: 4 },
-          { label: 'XL', value: 5 }
-        ]}
-        onChange={value => preferences.set('lineWidth', value)}
-      />
-      <SliderSetting
-        caption={t('preferences.symbolSize')}
-        defaultValue={preferences.get('symbolSize')}
-        marks={[
-          { label: 'S', value: 33 },
-          { label: 'M', value: 40 },
-          { label: 'L', value: 47 },
-          { label: 'XL', value: 54 }
-        ]}
-        onChange={value => preferences.set('symbolSize', value)}
-      />
-      <SwitchSetting defaultValue={preferences.get('symbolSizeByEchelon')}
-        onChange={value => preferences.set('symbolSizeByEchelon', value)}
-        label={t('preferences.symbolSizeByEchelon')}
-      />
-      <SwitchSetting defaultValue={preferences.get('simpleStatusModifier')}
-        onChange={value => preferences.set('simpleStatusModifier', value)}
-        label={t('preferences.simpleStatusModifier')}
-      />
+      <Paper variant='outlined' style={{ padding: '1em', marginBottom: '0.5em' }}>
+        <SliderSetting
+          caption={t('preferences.scheme.name')}
+          defaultValue={ schemeToSliderValue(preferences.get('scheme')) }
+          marks={[
+            { label: t('preferences.scheme.light'), value: 0 },
+            { label: t('preferences.scheme.medium'), value: 50 },
+            { label: t('preferences.scheme.dark'), value: 100 }
+          ]}
+          onChange={value => preferences.set('scheme', sliderValueToScheme(value))}
+        />
+      </Paper>
+      <Paper variant='outlined' style={{ padding: '1em', marginBottom: '0.5em' }}>
+        <SliderSetting
+          caption={t('preferences.lineWidth')}
+          defaultValue={preferences.get('lineWidth')}
+          marks={[
+            { label: 'S', value: 3 },
+            { label: 'M', value: 4 },
+            { label: 'L', value: 5 },
+            { label: 'XL', value: 6 }
+          ]}
+          onChange={value => preferences.set('lineWidth', value)}
+        />
+      </Paper>
+      <Paper variant='outlined' style={{ padding: '1em', marginBottom: '0.5em' }}>
+        <SliderSetting
+          caption={t('preferences.symbolSize')}
+          defaultValue={preferences.get('symbolSize')}
+          marks={[
+            { label: 'S', value: 30 },
+            { label: 'M', value: 40 },
+            { label: 'L', value: 50 },
+            { label: 'XL', value: 60 }
+          ]}
+          onChange={value => preferences.set('symbolSize', value)}
+        />
+        <SliderSetting
+          caption={t('preferences.symbolTextSize')}
+          defaultValue={preferences.get('symbolTextSize')}
+          marks={[
+            { label: 'S', value: 30 },
+            { label: 'M', value: 40 },
+            { label: 'L', value: 50 },
+            { label: 'XL', value: 60 }
+          ]}
+          onChange={value => preferences.set('symbolTextSize', value)}
+        />
+        <SwitchSetting defaultValue={preferences.get('symbolSizeByEchelon')}
+          onChange={value => preferences.set('symbolSizeByEchelon', value)}
+          label={t('preferences.symbolSizeByEchelon')}
+        />
+        <SwitchSetting defaultValue={preferences.get('simpleStatusModifier')}
+          onChange={value => preferences.set('simpleStatusModifier', value)}
+          label={t('preferences.simpleStatusModifier')}
+        />
+      </Paper>
     </Paper>
   },
   {

--- a/src/renderer/components/Activities.js
+++ b/src/renderer/components/Activities.js
@@ -87,12 +87,29 @@ const initialActivities = (classes, t) => [
           caption={t('preferences.lineWidth')}
           defaultValue={preferences.get('lineWidth')}
           marks={[
-            { label: 'S', value: 3 },
-            { label: 'M', value: 4 },
-            { label: 'L', value: 5 },
-            { label: 'XL', value: 6 }
+            { label: 'S', value: 2 },
+            { label: 'M', value: 3 },
+            { label: 'L', value: 4 },
+            { label: 'XL', value: 5 }
           ]}
           onChange={value => preferences.set('lineWidth', value)}
+        />
+      </Paper>
+      <Paper variant='outlined' style={{ padding: '1em', marginBottom: '0.5em' }}>
+        <SliderSetting
+          caption={t('preferences.labelTextSize')}
+          defaultValue={preferences.get('labelTextSize')}
+          marks={[
+            { value: 16, label: 'S' },
+            { value: 24, label: 'M' },
+            { value: 32, label: 'L' },
+            { value: 40, label: 'XL' }
+          ]}
+          onChange={value => preferences.set('labelTextSize', value)}
+        />
+        <SwitchSetting defaultValue={preferences.get('useBoldLabelText')}
+          onChange={value => preferences.set('useBoldLabelText', value)}
+          label={t('preferences.useBoldLabelText')}
         />
       </Paper>
       <Paper variant='outlined' style={{ padding: '1em', marginBottom: '0.5em' }}>

--- a/src/renderer/components/Activities.js
+++ b/src/renderer/components/Activities.js
@@ -14,6 +14,7 @@ import BasemapPanel from './basemapPanel/BasemapPanel'
 import LayerList from './layerlist/LayerList'
 import FeaturePalette from './palette/FeaturePalette'
 import SliderSetting from './settings/SliderSetting'
+import SwitchSetting from './settings/SwitchSetting'
 import undo from '../undo'
 import evented from '../evented'
 import preferences from '../project/preferences'
@@ -70,6 +71,16 @@ const initialActivities = (classes, t) => [
     tooltip: t('preferences.name'),
     panel: () => <Paper className={classes.toolsPanel} elevation={6}>
       <SliderSetting
+        caption={t('preferences.scheme.name')}
+        defaultValue={ schemeToSliderValue(preferences.get('scheme')) }
+        marks={[
+          { label: t('preferences.scheme.light'), value: 0 },
+          { label: t('preferences.scheme.medium'), value: 50 },
+          { label: t('preferences.scheme.dark'), value: 100 }
+        ]}
+        onChange={value => preferences.set('scheme', sliderValueToScheme(value))}
+      />
+      <SliderSetting
         caption={t('preferences.lineWidth')}
         defaultValue={preferences.get('lineWidth')}
         marks={[
@@ -91,15 +102,9 @@ const initialActivities = (classes, t) => [
         ]}
         onChange={value => preferences.set('symbolSize', value)}
       />
-      <SliderSetting
-        caption={t('preferences.scheme.name')}
-        defaultValue={ schemeToSliderValue(preferences.get('scheme')) }
-        marks={[
-          { label: t('preferences.scheme.light'), value: 0 },
-          { label: t('preferences.scheme.medium'), value: 50 },
-          { label: t('preferences.scheme.dark'), value: 100 }
-        ]}
-        onChange={value => preferences.set('scheme', sliderValueToScheme(value))}
+      <SwitchSetting defaultValue={preferences.get('simpleStatusModifier')}
+        onChange={value => preferences.set('simpleStatusModifier', value)}
+        label={t('preferences.simpleStatusModifier')}
       />
     </Paper>
   },

--- a/src/renderer/components/Activities.js
+++ b/src/renderer/components/Activities.js
@@ -18,6 +18,8 @@ import undo from '../undo'
 import evented from '../evented'
 import preferences from '../project/preferences'
 
+import { schemeToSliderValue, sliderValueToScheme } from './settings/util'
+
 import { useTranslation } from 'react-i18next'
 
 const useStyles = makeStyles((/* theme */) => ({
@@ -88,6 +90,16 @@ const initialActivities = (classes, t) => [
           { label: 'XL', value: 54 }
         ]}
         onChange={value => preferences.set('symbolSize', value)}
+      />
+      <SliderSetting
+        caption={t('preferences.scheme.name')}
+        defaultValue={ schemeToSliderValue(preferences.get('scheme')) }
+        marks={[
+          { label: t('preferences.scheme.light'), value: 0 },
+          { label: t('preferences.scheme.medium'), value: 50 },
+          { label: t('preferences.scheme.dark'), value: 100 }
+        ]}
+        onChange={value => preferences.set('scheme', sliderValueToScheme(value))}
       />
     </Paper>
   },

--- a/src/renderer/components/Activities.js
+++ b/src/renderer/components/Activities.js
@@ -6,14 +6,14 @@ import PermDataSettingIcon from '@material-ui/icons/PermDataSettingOutlined'
 import MapIcon from '@material-ui/icons/MapOutlined'
 import PhotoCameraIcon from '@material-ui/icons/PhotoCameraOutlined'
 import Button from '@material-ui/core/Button'
-import SettingsIcon from '@material-ui/icons/Settings'
+import SettingsIcon from '@material-ui/icons/SettingsOutlined'
 import { LayersTripleOutline, Undo, Redo, ContentCut, ContentCopy, ContentPaste } from 'mdi-material-ui'
 
 import ActivityBar from './ActivityBar'
 import BasemapPanel from './basemapPanel/BasemapPanel'
 import LayerList from './layerlist/LayerList'
 import FeaturePalette from './palette/FeaturePalette'
-import SliderSettings from './settings/SliderSetting'
+import SliderSetting from './settings/SliderSetting'
 import undo from '../undo'
 import evented from '../evented'
 import preferences from '../project/preferences'
@@ -62,13 +62,13 @@ const initialActivities = (classes, t) => [
     </Paper>
   },
   {
-    id: 'settings',
+    id: 'preferences',
     type: 'activity',
     icon: <SettingsIcon />,
-    tooltip: t('activities.tooltips.tools'),
+    tooltip: t('preferences.name'),
     panel: () => <Paper className={classes.toolsPanel} elevation={6}>
-      <SliderSettings
-        caption='Überschrift'
+      <SliderSetting
+        caption={t('preferences.lineWidth')}
         defaultValue={preferences.get('lineWidth')}
         marks={[
           { label: 'S', value: 2 },
@@ -77,6 +77,17 @@ const initialActivities = (classes, t) => [
           { label: 'XL', value: 5 }
         ]}
         onChange={value => preferences.set('lineWidth', value)}
+      />
+      <SliderSetting
+        caption={t('preferences.symbolSize')}
+        defaultValue={preferences.get('symbolSize')}
+        marks={[
+          { label: 'S', value: 33 },
+          { label: 'M', value: 40 },
+          { label: 'L', value: 47 },
+          { label: 'XL', value: 54 }
+        ]}
+        onChange={value => preferences.set('symbolSize', value)}
       />
     </Paper>
   },

--- a/src/renderer/components/settings/SliderSetting.js
+++ b/src/renderer/components/settings/SliderSetting.js
@@ -1,0 +1,40 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Slider, Typography } from '@material-ui/core'
+
+
+const SliderSettings = props => {
+
+  const minValue = props.marks.reduce((accu, current) =>
+    (current.value < accu) ? current.value : accu, 100)
+
+  const maxValue = props.marks.reduce((accu, current) =>
+    (current.value > accu) ? current.value : accu, 0)
+
+  return (
+    <>
+    <Typography id="discrete-slider-restrict" gutterBottom>
+      Line Width
+    </Typography>
+    <Slider
+      aria-labelledby="discrete-slider-restrict"
+      step={null}
+      valueLabelDisplay="off"
+      marks={props.marks}
+      defaultValue={props.defaultValue}
+      onChange={(_, value) => props.onChange(value)}
+      min={minValue}
+      max={maxValue}
+    />
+  </>
+  )
+}
+
+SliderSettings.propTypes = {
+  caption: PropTypes.string,
+  defaultValue: PropTypes.number.isRequired,
+  marks: PropTypes.array.isRequired,
+  onChange: PropTypes.func.isRequired
+}
+
+export default SliderSettings

--- a/src/renderer/components/settings/SliderSetting.js
+++ b/src/renderer/components/settings/SliderSetting.js
@@ -12,7 +12,7 @@ const SliderSetting = props => {
     (current.value > accu) ? current.value : accu, 0)
 
   return (
-  <div style={{ margin: '1em 0 1em 0' }}>
+  <div>
     <Typography id="discrete-slider-restrict">
       {props.caption}
     </Typography>

--- a/src/renderer/components/settings/SliderSetting.js
+++ b/src/renderer/components/settings/SliderSetting.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { Slider, Typography } from '@material-ui/core'
 
 
-const SliderSettings = props => {
+const SliderSetting = props => {
 
   const minValue = props.marks.reduce((accu, current) =>
     (current.value < accu) ? current.value : accu, 100)
@@ -12,9 +12,9 @@ const SliderSettings = props => {
     (current.value > accu) ? current.value : accu, 0)
 
   return (
-    <>
-    <Typography id="discrete-slider-restrict" gutterBottom>
-      Line Width
+  <div style={{ margin: '1em 0 1em 0' }}>
+    <Typography id="discrete-slider-restrict">
+      {props.caption}
     </Typography>
     <Slider
       aria-labelledby="discrete-slider-restrict"
@@ -26,15 +26,15 @@ const SliderSettings = props => {
       min={minValue}
       max={maxValue}
     />
-  </>
+  </div>
   )
 }
 
-SliderSettings.propTypes = {
+SliderSetting.propTypes = {
   caption: PropTypes.string,
   defaultValue: PropTypes.number.isRequired,
   marks: PropTypes.array.isRequired,
   onChange: PropTypes.func.isRequired
 }
 
-export default SliderSettings
+export default SliderSetting

--- a/src/renderer/components/settings/SwitchSetting.js
+++ b/src/renderer/components/settings/SwitchSetting.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Switch, FormControlLabel } from '@material-ui/core'
+
+const SwitchSetting = props => {
+
+  const [isChecked, setIsChecked] = React.useState(props.defaultValue)
+  const handleChange = event => {
+    setIsChecked(event.target.checked)
+    props.onChange(event.target.checked)
+  }
+
+  return (
+    <FormControlLabel
+        control={
+          <Switch
+            checked={isChecked}
+            onChange={handleChange}
+            color='primary'
+          />
+        }
+        label={props.label}
+      />
+  )
+}
+
+SwitchSetting.propTypes = {
+  defaultValue: PropTypes.bool.isRequired,
+  label: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired
+}
+
+export default SwitchSetting

--- a/src/renderer/components/settings/util.js
+++ b/src/renderer/components/settings/util.js
@@ -1,0 +1,15 @@
+export const schemeToSliderValue = scheme => {
+  switch (scheme) {
+    case 'light': return 0
+    case 'medium': return 50
+    case 'dark': return 100
+    default: return 50
+  }
+}
+
+export const sliderValueToScheme = value => {
+  if (value === 0) return 'light'
+  else if (value === 50) return 'medium'
+  else if (value === 100) return 'dark'
+  else return 'medium'
+}

--- a/src/renderer/map/Map.js
+++ b/src/renderer/map/Map.js
@@ -82,6 +82,7 @@ const effect = props => () => {
 
   // restore viewport and active layer name from preferences.
   preferences.register(event => {
+    console.dir(event)
     const { type, preferences, key } = event
     if (type === 'preferences') {
       const { activeLayer } = preferences
@@ -90,7 +91,7 @@ const effect = props => () => {
       const { center, zoom } = preferences.viewport
       view.setCenter(fromLonLat(center))
       view.setZoom(zoom)
-    } else if (key === 'labels') {
+    } else if (key === 'labels' || key === 'lineWidth') {
       map.getLayers().forEach(layer => {
         if (layer instanceof VectorLayer) layer.changed()
       })

--- a/src/renderer/map/Map.js
+++ b/src/renderer/map/Map.js
@@ -83,6 +83,7 @@ const effect = props => () => {
   // restore viewport and active layer name from preferences.
   preferences.register(event => {
     const { type, preferences, key } = event
+    const triggerKeys = ['labels', 'lineWidth', 'symbolSize', 'scheme', 'simpleStatusModifier']
     if (type === 'preferences') {
       const { activeLayer } = preferences
       if (activeLayer) evented.emit('OSD_MESSAGE', { message: activeLayer, slot: 'A2' })
@@ -90,7 +91,7 @@ const effect = props => () => {
       const { center, zoom } = preferences.viewport
       view.setCenter(fromLonLat(center))
       view.setZoom(zoom)
-    } else if (key === 'labels' || key === 'lineWidth' || key === 'symbolSize' || key === 'scheme') {
+    } else if (triggerKeys.includes(key)) {
       map.getLayers().forEach(layer => {
         if (layer instanceof VectorLayer) layer.changed()
       })

--- a/src/renderer/map/Map.js
+++ b/src/renderer/map/Map.js
@@ -90,7 +90,7 @@ const effect = props => () => {
       const { center, zoom } = preferences.viewport
       view.setCenter(fromLonLat(center))
       view.setZoom(zoom)
-    } else if (key === 'labels' || key === 'lineWidth' || key === 'symbolSize') {
+    } else if (key === 'labels' || key === 'lineWidth' || key === 'symbolSize' || key === 'scheme') {
       map.getLayers().forEach(layer => {
         if (layer instanceof VectorLayer) layer.changed()
       })

--- a/src/renderer/map/Map.js
+++ b/src/renderer/map/Map.js
@@ -83,7 +83,7 @@ const effect = props => () => {
   // restore viewport and active layer name from preferences.
   preferences.register(event => {
     const { type, preferences, key } = event
-    const triggerKeys = ['labels', 'lineWidth', 'symbolSize', 'scheme', 'simpleStatusModifier', 'symbolSizeByEchelon', 'symbolTextSize']
+    const triggerKeys = ['labels', 'lineWidth', 'symbolSize', 'scheme', 'simpleStatusModifier', 'symbolSizeByEchelon', 'symbolTextSize', 'labelTextSize', 'useBoldLabelText']
     if (type === 'preferences') {
       const { activeLayer } = preferences
       if (activeLayer) evented.emit('OSD_MESSAGE', { message: activeLayer, slot: 'A2' })

--- a/src/renderer/map/Map.js
+++ b/src/renderer/map/Map.js
@@ -82,7 +82,6 @@ const effect = props => () => {
 
   // restore viewport and active layer name from preferences.
   preferences.register(event => {
-    console.dir(event)
     const { type, preferences, key } = event
     if (type === 'preferences') {
       const { activeLayer } = preferences

--- a/src/renderer/map/Map.js
+++ b/src/renderer/map/Map.js
@@ -83,7 +83,7 @@ const effect = props => () => {
   // restore viewport and active layer name from preferences.
   preferences.register(event => {
     const { type, preferences, key } = event
-    const triggerKeys = ['labels', 'lineWidth', 'symbolSize', 'scheme', 'simpleStatusModifier', 'symbolSizeByEchelon']
+    const triggerKeys = ['labels', 'lineWidth', 'symbolSize', 'scheme', 'simpleStatusModifier', 'symbolSizeByEchelon', 'symbolTextSize']
     if (type === 'preferences') {
       const { activeLayer } = preferences
       if (activeLayer) evented.emit('OSD_MESSAGE', { message: activeLayer, slot: 'A2' })

--- a/src/renderer/map/Map.js
+++ b/src/renderer/map/Map.js
@@ -90,7 +90,7 @@ const effect = props => () => {
       const { center, zoom } = preferences.viewport
       view.setCenter(fromLonLat(center))
       view.setZoom(zoom)
-    } else if (key === 'labels' || key === 'lineWidth') {
+    } else if (key === 'labels' || key === 'lineWidth' || key === 'symbolSize') {
       map.getLayers().forEach(layer => {
         if (layer instanceof VectorLayer) layer.changed()
       })

--- a/src/renderer/map/Map.js
+++ b/src/renderer/map/Map.js
@@ -83,7 +83,7 @@ const effect = props => () => {
   // restore viewport and active layer name from preferences.
   preferences.register(event => {
     const { type, preferences, key } = event
-    const triggerKeys = ['labels', 'lineWidth', 'symbolSize', 'scheme', 'simpleStatusModifier']
+    const triggerKeys = ['labels', 'lineWidth', 'symbolSize', 'scheme', 'simpleStatusModifier', 'symbolSizeByEchelon']
     if (type === 'preferences') {
       const { activeLayer } = preferences
       if (activeLayer) evented.emit('OSD_MESSAGE', { message: activeLayer, slot: 'A2' })

--- a/src/renderer/map/style/default-style.js
+++ b/src/renderer/map/style/default-style.js
@@ -6,8 +6,7 @@ import preferences from '../../project/preferences'
 import { noop } from '../../../shared/combinators'
 
 let labels = true
-
-const USER_DEFINED_LINE_SCALE = process.env.USER_DEFINED_LINE_SCALE || 1
+let lineWidth = 3
 
 const handlers = {
   preferences: ({ preferences }) => {
@@ -29,7 +28,10 @@ const handlers = {
 }
 
 preferences.register(event => (handlers[event.type] || noop)(event))
-
+preferences.register(({ key, value }) => {
+  if (key !== 'lineWidth') return
+  lineWidth = value
+})
 
 ipcRenderer.on('IPC_TOGGLE_LABELS', () => {
   preferences.set('labels', !labels)
@@ -51,10 +53,13 @@ export const styleOptions = ({ feature }) => {
     primaryColor: primaryColor(scheme)(SIDC.identity(sidc)),
     accentColor: accentColor(SIDC.identity(sidc)),
     dashPattern: SIDC.status(sidc) === 'A' ? [20, 10] : null,
-    thin: 2 * USER_DEFINED_LINE_SCALE,
-    thick: 3.5 * USER_DEFINED_LINE_SCALE
+    thin: lineWidth,
+    thick: 1.75 * lineWidth
   }
 }
+
+export const defaultFont = `${lineWidth * 7}px sans-serif`
+export const biggerFont = `${(1 + lineWidth) * 7}px sans-serif`
 
 const factory = options => write => {
   const { mode, resolution } = options
@@ -72,7 +77,7 @@ const factory = options => write => {
     },
 
     singleLine: (inGeometry, opts = {}) => {
-      const width = opts.width || 3 * USER_DEFINED_LINE_SCALE
+      const width = opts.width || lineWidth
       const color = opts.color || options.primaryColor
       const fill = opts.fill
       const geometry = write(inGeometry)
@@ -155,7 +160,7 @@ const factory = options => write => {
       return style({
         geometry: write(inGeometry),
         text: text({
-          font: '16px sans-serif',
+          font: biggerFont,
           stroke: stroke({ color: 'white', width: 3 }),
           fill: fill({ color: fillColor }),
           ...options,
@@ -173,8 +178,6 @@ const factory = options => write => {
   }
 }
 
-export const defaultFont = `${14 * USER_DEFINED_LINE_SCALE}px sans-serif`
-export const biggerFont = `${16 * USER_DEFINED_LINE_SCALE}px sans-serif`
 
 const defaultImage = circle({
   radius: 6,

--- a/src/renderer/map/style/default-style.js
+++ b/src/renderer/map/style/default-style.js
@@ -8,6 +8,14 @@ import { noop } from '../../../shared/combinators'
 let labels = true
 let lineWidth = 3
 let symbolSize = 40
+let scheme = 'medium'
+
+const capitalize = value => {
+  if (!value) return
+  const objective = Array.from(value)
+  objective[0] = objective[0].toUpperCase()
+  return objective.join('')
+}
 
 const handlers = {
   preferences: ({ preferences }) => {
@@ -16,8 +24,7 @@ const handlers = {
       : preferences.labels || true
     ipcRenderer.send('IPC_LABELS_TOGGLED', labels)
 
-    lineWidth = preferences.lineWidth
-    symbolSize = preferences.symbolSize
+    ;({ lineWidth, symbolSize, scheme } = preferences)
   },
   set: ({ key, value }) => {
     if (key === 'labels') {
@@ -27,6 +34,8 @@ const handlers = {
       lineWidth = value
     } else if (key === 'symbolSize') {
       symbolSize = value
+    } else if (key === 'scheme') {
+      scheme = value
     }
   },
   unset: ({ key }) => {
@@ -50,7 +59,7 @@ const fill = options => new styles.Fill(options)
 const text = options => new styles.Text(options)
 const regularShape = options => new styles.RegularShape(options)
 
-const scheme = 'medium'
+
 export const styleOptions = ({ feature }) => {
   const sidc = feature.get('sidc')
 
@@ -60,7 +69,8 @@ export const styleOptions = ({ feature }) => {
     dashPattern: SIDC.status(sidc) === 'A' ? [20, 10] : null,
     thin: lineWidth,
     thick: 1.75 * lineWidth,
-    symbolScale: symbolSize
+    symbolScale: symbolSize,
+    scheme: capitalize(scheme)
   }
 }
 

--- a/src/renderer/map/style/default-style.js
+++ b/src/renderer/map/style/default-style.js
@@ -14,11 +14,16 @@ const handlers = {
       ? false
       : preferences.labels || true
     ipcRenderer.send('IPC_LABELS_TOGGLED', labels)
+
+    lineWidth = preferences.lineWidth
   },
   set: ({ key, value }) => {
-    if (key !== 'labels') return
-    labels = value
-    ipcRenderer.send('IPC_LABELS_TOGGLED', labels)
+    if (key === 'labels') {
+      labels = value
+      ipcRenderer.send('IPC_LABELS_TOGGLED', labels)
+    } else if (key === 'lineWidth') {
+      lineWidth = value
+    }
   },
   unset: ({ key }) => {
     if (key !== 'labels') return
@@ -28,10 +33,6 @@ const handlers = {
 }
 
 preferences.register(event => (handlers[event.type] || noop)(event))
-preferences.register(({ key, value }) => {
-  if (key !== 'lineWidth') return
-  lineWidth = value
-})
 
 ipcRenderer.on('IPC_TOGGLE_LABELS', () => {
   preferences.set('labels', !labels)
@@ -58,8 +59,8 @@ export const styleOptions = ({ feature }) => {
   }
 }
 
-export const defaultFont = `${lineWidth * 7}px sans-serif`
-export const biggerFont = `${(1 + lineWidth) * 7}px sans-serif`
+export const defaultFont = () => `${lineWidth * 7}px sans-serif`
+export const biggerFont = () => `${(1 + lineWidth) * 7}px sans-serif`
 
 const factory = options => write => {
   const { mode, resolution } = options
@@ -160,7 +161,7 @@ const factory = options => write => {
       return style({
         geometry: write(inGeometry),
         text: text({
-          font: biggerFont,
+          font: biggerFont(),
           stroke: stroke({ color: 'white', width: 3 }),
           fill: fill({ color: fillColor }),
           ...options,

--- a/src/renderer/map/style/default-style.js
+++ b/src/renderer/map/style/default-style.js
@@ -11,6 +11,7 @@ let symbolSize = 40
 let scheme = 'medium'
 let simpleStatusModifier = false
 let symbolSizeByEchelon = true
+let symbolTextSize = 40
 
 const capitalize = value => {
   if (!value) return
@@ -26,7 +27,7 @@ const handlers = {
       : preferences.labels || true
     ipcRenderer.send('IPC_LABELS_TOGGLED', labels)
 
-    ;({ lineWidth, symbolSize, scheme, simpleStatusModifier } = preferences)
+    ;({ lineWidth, symbolSize, scheme, simpleStatusModifier, symbolTextSize } = preferences)
   },
   set: ({ key, value }) => {
     if (key === 'labels') {
@@ -42,6 +43,8 @@ const handlers = {
       simpleStatusModifier = value
     } else if (key === 'symbolSizeByEchelon') {
       symbolSizeByEchelon = value
+    } else if (key === 'symbolTextSize') {
+      symbolTextSize = value
     }
   },
   unset: ({ key }) => {
@@ -78,7 +81,8 @@ export const styleOptions = ({ feature }) => {
     symbolSize,
     scheme: capitalize(scheme),
     simpleStatusModifier,
-    symbolSizeByEchelon
+    symbolSizeByEchelon,
+    symbolTextSize
   }
 }
 

--- a/src/renderer/map/style/default-style.js
+++ b/src/renderer/map/style/default-style.js
@@ -10,6 +10,7 @@ let lineWidth = 3
 let symbolSize = 40
 let scheme = 'medium'
 let simpleStatusModifier = false
+let symbolSizeByEchelon = true
 
 const capitalize = value => {
   if (!value) return
@@ -39,6 +40,8 @@ const handlers = {
       scheme = value
     } else if (key === 'simpleStatusModifier') {
       simpleStatusModifier = value
+    } else if (key === 'symbolSizeByEchelon') {
+      symbolSizeByEchelon = value
     }
   },
   unset: ({ key }) => {
@@ -72,9 +75,10 @@ export const styleOptions = ({ feature }) => {
     dashPattern: SIDC.status(sidc) === 'A' ? [20, 10] : null,
     thin: lineWidth,
     thick: 1.75 * lineWidth,
-    symbolSize: symbolSize,
+    symbolSize,
     scheme: capitalize(scheme),
-    simpleStatusModifier: simpleStatusModifier
+    simpleStatusModifier,
+    symbolSizeByEchelon
   }
 }
 

--- a/src/renderer/map/style/default-style.js
+++ b/src/renderer/map/style/default-style.js
@@ -9,6 +9,7 @@ let labels = true
 let lineWidth = 3
 let symbolSize = 40
 let scheme = 'medium'
+let simpleStatusModifier = false
 
 const capitalize = value => {
   if (!value) return
@@ -24,7 +25,7 @@ const handlers = {
       : preferences.labels || true
     ipcRenderer.send('IPC_LABELS_TOGGLED', labels)
 
-    ;({ lineWidth, symbolSize, scheme } = preferences)
+    ;({ lineWidth, symbolSize, scheme, simpleStatusModifier } = preferences)
   },
   set: ({ key, value }) => {
     if (key === 'labels') {
@@ -36,6 +37,8 @@ const handlers = {
       symbolSize = value
     } else if (key === 'scheme') {
       scheme = value
+    } else if (key === 'simpleStatusModifier') {
+      simpleStatusModifier = value
     }
   },
   unset: ({ key }) => {
@@ -69,8 +72,9 @@ export const styleOptions = ({ feature }) => {
     dashPattern: SIDC.status(sidc) === 'A' ? [20, 10] : null,
     thin: lineWidth,
     thick: 1.75 * lineWidth,
-    symbolScale: symbolSize,
-    scheme: capitalize(scheme)
+    symbolSize: symbolSize,
+    scheme: capitalize(scheme),
+    simpleStatusModifier: simpleStatusModifier
   }
 }
 

--- a/src/renderer/map/style/default-style.js
+++ b/src/renderer/map/style/default-style.js
@@ -7,6 +7,7 @@ import { noop } from '../../../shared/combinators'
 
 let labels = true
 let lineWidth = 3
+let symbolSize = 40
 
 const handlers = {
   preferences: ({ preferences }) => {
@@ -16,6 +17,7 @@ const handlers = {
     ipcRenderer.send('IPC_LABELS_TOGGLED', labels)
 
     lineWidth = preferences.lineWidth
+    symbolSize = preferences.symbolSize
   },
   set: ({ key, value }) => {
     if (key === 'labels') {
@@ -23,6 +25,8 @@ const handlers = {
       ipcRenderer.send('IPC_LABELS_TOGGLED', labels)
     } else if (key === 'lineWidth') {
       lineWidth = value
+    } else if (key === 'symbolSize') {
+      symbolSize = value
     }
   },
   unset: ({ key }) => {
@@ -55,12 +59,13 @@ export const styleOptions = ({ feature }) => {
     accentColor: accentColor(SIDC.identity(sidc)),
     dashPattern: SIDC.status(sidc) === 'A' ? [20, 10] : null,
     thin: lineWidth,
-    thick: 1.75 * lineWidth
+    thick: 1.75 * lineWidth,
+    symbolScale: symbolSize
   }
 }
 
-export const defaultFont = () => `${lineWidth * 7}px sans-serif`
-export const biggerFont = () => `${(1 + lineWidth) * 7}px sans-serif`
+export const defaultFont = () => `${lineWidth * 7 + 2}px sans-serif`
+export const biggerFont = () => `${lineWidth * 7 + 4}px sans-serif`
 
 const factory = options => write => {
   const { mode, resolution } = options

--- a/src/renderer/map/style/default-style.js
+++ b/src/renderer/map/style/default-style.js
@@ -7,6 +7,8 @@ import { noop } from '../../../shared/combinators'
 
 let labels = true
 
+const USER_DEFINED_LINE_SCALE = process.env.USER_DEFINED_LINE_SCALE || 1
+
 const handlers = {
   preferences: ({ preferences }) => {
     labels = preferences.labels === false
@@ -49,8 +51,8 @@ export const styleOptions = ({ feature }) => {
     primaryColor: primaryColor(scheme)(SIDC.identity(sidc)),
     accentColor: accentColor(SIDC.identity(sidc)),
     dashPattern: SIDC.status(sidc) === 'A' ? [20, 10] : null,
-    thin: 2,
-    thick: 3.5
+    thin: 2 * USER_DEFINED_LINE_SCALE,
+    thick: 3.5 * USER_DEFINED_LINE_SCALE
   }
 }
 
@@ -70,7 +72,7 @@ const factory = options => write => {
     },
 
     singleLine: (inGeometry, opts = {}) => {
-      const width = opts.width || 3
+      const width = opts.width || 3 * USER_DEFINED_LINE_SCALE
       const color = opts.color || options.primaryColor
       const fill = opts.fill
       const geometry = write(inGeometry)
@@ -171,8 +173,8 @@ const factory = options => write => {
   }
 }
 
-export const defaultFont = '14px sans-serif'
-export const biggerFont = '16px sans-serif'
+export const defaultFont = `${14 * USER_DEFINED_LINE_SCALE}px sans-serif`
+export const biggerFont = `${16 * USER_DEFINED_LINE_SCALE}px sans-serif`
 
 const defaultImage = circle({
   radius: 6,

--- a/src/renderer/map/style/default-style.js
+++ b/src/renderer/map/style/default-style.js
@@ -12,6 +12,8 @@ let scheme = 'medium'
 let simpleStatusModifier = false
 let symbolSizeByEchelon = true
 let symbolTextSize = 40
+let labelTextSize = 16
+let useBoldLabelText = false
 
 const capitalize = value => {
   if (!value) return
@@ -27,7 +29,7 @@ const handlers = {
       : preferences.labels || true
     ipcRenderer.send('IPC_LABELS_TOGGLED', labels)
 
-    ;({ lineWidth, symbolSize, scheme, simpleStatusModifier, symbolTextSize } = preferences)
+    ;({ lineWidth, symbolSize, scheme, simpleStatusModifier, symbolTextSize, labelTextSize, useBoldLabelText } = preferences)
   },
   set: ({ key, value }) => {
     if (key === 'labels') {
@@ -45,6 +47,10 @@ const handlers = {
       symbolSizeByEchelon = value
     } else if (key === 'symbolTextSize') {
       symbolTextSize = value
+    } else if (key === 'labelTextSize') {
+      labelTextSize = value
+    } else if (key === 'useBoldLabelText') {
+      useBoldLabelText = value
     }
   },
   unset: ({ key }) => {
@@ -86,8 +92,8 @@ export const styleOptions = ({ feature }) => {
   }
 }
 
-export const defaultFont = () => `${lineWidth * 7 + 2}px sans-serif`
-export const biggerFont = () => `${lineWidth * 7 + 4}px sans-serif`
+export const defaultFont = () => `${useBoldLabelText ? 'bold' : ''} ${labelTextSize + 2}px sans-serif`
+export const biggerFont = () => `${useBoldLabelText ? 'bold' : ''} ${labelTextSize + 4}px sans-serif`
 
 const factory = options => write => {
   const { mode, resolution } = options

--- a/src/renderer/map/style/labels-polygon.js
+++ b/src/renderer/map/style/labels-polygon.js
@@ -84,7 +84,7 @@ const textStyle = ({ geometry, text, options }) => new style.Style({
   geometry,
   text: new style.Text({
     text,
-    font: defaultFont,
+    font: defaultFont(),
     stroke: new style.Stroke({ color: 'white', width: 3 }),
     ...options
   })

--- a/src/renderer/map/style/line-labels.js
+++ b/src/renderer/map/style/line-labels.js
@@ -94,7 +94,7 @@ export const label = options => lines => feature => {
     geometry: new geom.Point(point(options)),
     text: new style.Text({
       text: lines(feature.getProperties()).filter(x => x).join('\n'),
-      font: defaultFont,
+      font: defaultFont(),
       stroke: defaultStroke,
       rotation: flip(α) ? α - _PI : α,
       textAlign: textAlign(α)(options),

--- a/src/renderer/map/style/multipoint-style.js
+++ b/src/renderer/map/style/multipoint-style.js
@@ -10,7 +10,7 @@ const geometries = {}
 
 const arcText = styles => (anchor, angle, text) => styles.text(anchor, {
   text,
-  font: biggerFont,
+  font: biggerFont(),
   flip: true,
   textAlign: () => 'center',
   rotation: Math.PI - angle + 330 / 2 * deg2rad

--- a/src/renderer/map/style/polygon-labels.js
+++ b/src/renderer/map/style/polygon-labels.js
@@ -86,7 +86,7 @@ export const textStyle = ({ geometry, text, options }) => new style.Style({
   geometry,
   text: new style.Text({
     text,
-    font: defaultFont,
+    font: defaultFont(),
     stroke: new style.Stroke({ color: 'white', width: 3 }),
     ...options
   })

--- a/src/renderer/map/style/symbol-style.js
+++ b/src/renderer/map/style/symbol-style.js
@@ -79,7 +79,8 @@ export const symbolStyle = mode => (feature, resolution) => {
   }
 
   options.colorMode = style.scheme
-  options.size = style.symbolScale
+  options.size = style.symbolSize
+  options.simpleStatusModifier = style.simpleStatusModifier
 
   const symbol = new ms.Symbol(actualSIDC, options)
   const geometry = feature.getGeometry()

--- a/src/renderer/map/style/symbol-style.js
+++ b/src/renderer/map/style/symbol-style.js
@@ -94,6 +94,7 @@ export const symbolStyle = mode => (feature, resolution) => {
   options.colorMode = style.scheme
   options.size = style.symbolSizeByEchelon ? symbolSizeBySIDC(actualSIDC, style.symbolSize) : style.symbolSize
   options.simpleStatusModifier = style.simpleStatusModifier
+  options.infoSize = style.symbolTextSize
 
   const symbol = new ms.Symbol(actualSIDC, options)
   const geometry = feature.getGeometry()

--- a/src/renderer/map/style/symbol-style.js
+++ b/src/renderer/map/style/symbol-style.js
@@ -5,8 +5,6 @@ import ms from 'milsymbol'
 import { K } from '../../../shared/combinators'
 import { defaultStyle, styleFactory, styleOptions } from './default-style'
 
-const USER_DEFINED_SYMBOL_SCALE = (process.env.USER_DEFINED_SYMBOL_SCALE || 1)
-
 const MODIFIERS = {
   c: 'quantity',
   f: 'reinforcedReduced',
@@ -38,7 +36,6 @@ const icon = symbol => {
   const imgSize = size => [Math.floor(size.width), Math.floor(size.height)]
   return new Icon({
     anchor,
-    scale: 0.4 * USER_DEFINED_SYMBOL_SCALE,
     anchorXUnits: 'pixels',
     anchorYUnits: 'pixels',
     imgSize: imgSize(symbol.getSize()),
@@ -78,6 +75,8 @@ export const symbolStyle = mode => (feature, resolution) => {
       options.outlineColor = styleOptions({ feature }).accentColor
     }
   }
+
+  options.size = styleOptions({ feature }).symbolScale
 
   const symbol = new ms.Symbol(actualSIDC, options)
   const geometry = feature.getGeometry()

--- a/src/renderer/map/style/symbol-style.js
+++ b/src/renderer/map/style/symbol-style.js
@@ -38,9 +38,11 @@ const symbolSizeBySIDC = (sidc, defaultSize) => {
 
   const echelon = echelonPart.value(sidc)
   if (!echelon || echelon === '-') return defaultSize
-  if (echelon >= 'H') return Math.floor(1.5 * defaultSize) // Brigade or bigger
-  if (echelon >= 'F') return Math.floor(1.25 * defaultSize) // Bataillon or Regiment
-  if (echelon === 'E') return Math.floor(1.125 * defaultSize) // Company
+  if (echelon >= 'H') return Math.floor(1.55 * defaultSize) // Brigade or bigger
+  if (echelon >= 'F') return Math.floor(1.34 * defaultSize) // Bataillon or Regiment
+  if (echelon === 'E') return Math.floor(1.21 * defaultSize) // Company
+  if (echelon === 'D') return Math.floor(1.13 * defaultSize) // Platoon
+  if (echelon === 'C') return Math.floor(1.08 * defaultSize) // Section
   return defaultSize
 }
 

--- a/src/renderer/map/style/symbol-style.js
+++ b/src/renderer/map/style/symbol-style.js
@@ -59,6 +59,8 @@ export const symbolStyle = mode => (feature, resolution) => {
     infoFields
   }
 
+  const style = styleOptions({ feature })
+
   let actualSIDC = sidc
   if (sidc && sidc[0] === 'G') {
     // MilSymbols cannot handle undefined hostility
@@ -70,13 +72,14 @@ export const symbolStyle = mode => (feature, resolution) => {
       actualSIDC = chars.join('')
     } else {
       // Set mono color according to hostility state.
-      const color = styleOptions({ feature }).primaryColor
+      const color = style.primaryColor
       options.monoColor = color
-      options.outlineColor = styleOptions({ feature }).accentColor
+      options.outlineColor = style.accentColor
     }
   }
 
-  options.size = styleOptions({ feature }).symbolScale
+  options.colorMode = style.scheme
+  options.size = style.symbolScale
 
   const symbol = new ms.Symbol(actualSIDC, options)
   const geometry = feature.getGeometry()

--- a/src/renderer/map/style/symbol-style.js
+++ b/src/renderer/map/style/symbol-style.js
@@ -5,6 +5,8 @@ import ms from 'milsymbol'
 import { K } from '../../../shared/combinators'
 import { defaultStyle, styleFactory, styleOptions } from './default-style'
 
+const USER_DEFINED_SYMBOL_SCALE = (process.env.USER_DEFINED_SYMBOL_SCALE || 1)
+
 const MODIFIERS = {
   c: 'quantity',
   f: 'reinforcedReduced',
@@ -36,7 +38,7 @@ const icon = symbol => {
   const imgSize = size => [Math.floor(size.width), Math.floor(size.height)]
   return new Icon({
     anchor,
-    scale: 0.4,
+    scale: 0.4 * USER_DEFINED_SYMBOL_SCALE,
     anchorXUnits: 'pixels',
     anchorYUnits: 'pixels',
     imgSize: imgSize(symbol.getSize()),

--- a/src/renderer/project/io.js
+++ b/src/renderer/project/io.js
@@ -12,7 +12,7 @@ export const loadPreferences = defaults => {
   const location = path.join(projectPath(), 'preferences.json')
   if (!fs.existsSync(location)) return defaults
 
-  return K(JSON.parse(fs.readFileSync(location)))(preferences => {
+  const persistedDefaults = K(JSON.parse(fs.readFileSync(location)))(preferences => {
 
     // Upgrade existing preferences:
     //    activeLayer :: string [name of active aka target layer]
@@ -23,6 +23,8 @@ export const loadPreferences = defaults => {
       writeLayer(name, contents)
     }
   })
+
+  return { ...defaults, ...persistedDefaults }
 }
 
 /**

--- a/src/renderer/project/preferences.js
+++ b/src/renderer/project/preferences.js
@@ -8,7 +8,9 @@ const DEFAULT_PREFERENCES = {
       15.517894187589647,
       48.21987507926943
     ]
-  }
+  },
+  lineWidth: 3,
+  scmbolScale: 1
 }
 
 

--- a/src/renderer/project/preferences.js
+++ b/src/renderer/project/preferences.js
@@ -10,7 +10,8 @@ const DEFAULT_PREFERENCES = {
     ]
   },
   lineWidth: 3,
-  symbolSize: 40
+  symbolSize: 40,
+  scheme: 'medium'
 }
 
 

--- a/src/renderer/project/preferences.js
+++ b/src/renderer/project/preferences.js
@@ -14,7 +14,8 @@ const DEFAULT_PREFERENCES = {
   scheme: 'medium',
   simpleStatusModifier: false,
   symbolSizeByEchelon: true,
-  symbolTextSize: 40
+  symbolTextSize: 40,
+  useBoldLabelText: false
 }
 
 

--- a/src/renderer/project/preferences.js
+++ b/src/renderer/project/preferences.js
@@ -10,7 +10,7 @@ const DEFAULT_PREFERENCES = {
     ]
   },
   lineWidth: 3,
-  scmbolScale: 1
+  symbolSize: 40
 }
 
 

--- a/src/renderer/project/preferences.js
+++ b/src/renderer/project/preferences.js
@@ -11,7 +11,8 @@ const DEFAULT_PREFERENCES = {
   },
   lineWidth: 3,
   symbolSize: 40,
-  scheme: 'medium'
+  scheme: 'medium',
+  simpleStatusModifier: false
 }
 
 

--- a/src/renderer/project/preferences.js
+++ b/src/renderer/project/preferences.js
@@ -13,7 +13,8 @@ const DEFAULT_PREFERENCES = {
   symbolSize: 40,
   scheme: 'medium',
   simpleStatusModifier: false,
-  symbolSizeByEchelon: true
+  symbolSizeByEchelon: true,
+  symbolTextSize: 40
 }
 
 

--- a/src/renderer/project/preferences.js
+++ b/src/renderer/project/preferences.js
@@ -12,7 +12,8 @@ const DEFAULT_PREFERENCES = {
   lineWidth: 3,
   symbolSize: 40,
   scheme: 'medium',
-  simpleStatusModifier: false
+  simpleStatusModifier: false,
+  symbolSizeByEchelon: true
 }
 
 


### PR DESCRIPTION
User do now have control about some aspects of the styling of tactical symbols. They can

* change color preset (light, medium, dark)
* change the line width of tactical graphics, boundaries, areas, ...
* change the font size and weight for labels of lines, areas, ...
* change the size of symbols with point geometry and the size of the symbol label
* enable sizing based on the echelon
* choose between simple and extended status of point based symbols
