### PR TITLE
Correction place of text in task "RIP"

### DIFF
--- a/src/renderer/map/style/corridors/G_T_R.js
+++ b/src/renderer/map/style/corridors/G_T_R.js
@@ -15,6 +15,7 @@ export default options => {
   const [px] = TS.projectCoordinates(width / 4, angle, coords[1])([[0, -orientation]])
   const [p0] = TS.projectCoordinates(width / 2, angle, coords[0])([[0, -orientation]])
   const [p1] = TS.projectCoordinates(width / 2, angle, coords[1])([[0, -orientation]])
+  const [p2] = TS.projectCoordinates(width / 4, angle, coords[0])([[2, -orientation]])
 
   const arc = TS.difference([
     TS.boundary(TS.pointBuffer(TS.point(px))(width / 4)),
@@ -29,7 +30,7 @@ export default options => {
       openArrow(resolution, angle + Math.PI, p0),
       arc
     ])),
-    styles.text(TS.point(segment.midPoint()), {
+    styles.text(TS.point(p2), {
       text: 'RIP',
       flip: true,
       rotation: Math.PI - angle


### PR DESCRIPTION
The text "RIP" is now displayed inside the symbol and no longer on the top line (according to MILSTD-2525/App6).