### PR TITLE
Change Properties for 3 EMS "Equipment" symbols

### DIFF
--- a/src/renderer/components/feature-descriptors.json
+++ b/src/renderer/components/feature-descriptors.json
@@ -117,7 +117,7 @@
   {
     "standard": "MIL-STD-2525C",
     "sidc": "E*F*BA----*****",
-    "class": "EI",
+    "class": "E",
     "scope": "INSTALLATION",
     "geometry": "Point",
     "dimension": "EMS",
@@ -759,7 +759,7 @@
   {
     "standard": "MIL-STD-2525C",
     "sidc": "E*F*MA----*****",
-    "class": "EI",
+    "class": "E",
     "scope": "INSTALLATION",
     "geometry": "Point",
     "dimension": "EMS",
@@ -785,7 +785,7 @@
   {
     "standard": "MIL-STD-2525C",
     "sidc": "E*F*MC----*****",
-    "class": "EI",
+    "class": "E",
     "scope": "INSTALLATION",
     "geometry": "Point",
     "dimension": "EMS",


### PR DESCRIPTION
For following EMS symbols the properties have been changed from Installation to Equipment:

- ATM
- Control Valve
- Discharge Outfall

These are listed in MILSTD-2525C in infrastructure section, but the tactical symbol corresponds to those of equipment.