### PR TITLE
Improved UI for editing layer names

### DIFF
--- a/src/renderer/components/layerlist/LayerLineEntry.js
+++ b/src/renderer/components/layerlist/LayerLineEntry.js
@@ -4,6 +4,7 @@ import { makeStyles } from '@material-ui/core/styles'
 import { List, ListItem, ListItemText, ListItemSecondaryAction } from '@material-ui/core'
 import Collapse from '@material-ui/core/Collapse'
 import IconButton from '@material-ui/core/IconButton'
+import EditIcon from '@material-ui/icons/Edit'
 import LockIcon from '@material-ui/icons/Lock'
 import LockOpenIcon from '@material-ui/icons/LockOpen'
 import VisibilityIcon from '@material-ui/icons/Visibility'
@@ -66,6 +67,11 @@ export const LayerLineEntry = props => {
 
         <ListItemSecondaryAction>
           <IconButton
+            size='small'
+            onClick={props.editLayerName}>
+            <EditIcon/>
+          </IconButton>
+          <IconButton
             disabled={lockToggleDisabled}
             size='small'
             onClick={toggleLayerLock}
@@ -103,5 +109,6 @@ LayerLineEntry.propTypes = {
   locked: PropTypes.bool, // optional, false if omitted
   hidden: PropTypes.bool, // optional, false if omitted
   expanded: PropTypes.bool, // optional, false if omitted
-  selectLayer: PropTypes.func.isRequired
+  selectLayer: PropTypes.func.isRequired,
+  editLayerName: PropTypes.func.isRequired
 }

--- a/src/renderer/components/layerlist/LayerList.js
+++ b/src/renderer/components/layerlist/LayerList.js
@@ -44,6 +44,10 @@ const LayerList = (/* props */) => {
   const reducer = (state, event) => (handlers[event.type] || I)(state, event)
   const [layers, dispatch] = React.useReducer(reducer, {})
 
+  const editLayerName = (layerId) => () => {
+    dispatch({ type: 'editoractivated', layerId: layerId })
+  }
+
   const selectedLayerId = () => {
     const selected = selection.selected(URI.isLayerId)
     return selected.length ? selected[0] : null
@@ -116,6 +120,7 @@ const LayerList = (/* props */) => {
         key={layer.id}
         { ...layer }
         selectLayer={selectLayer(layer.id)}
+        editLayerName={editLayerName(layer.id)}
       />
 
   const sortedLayers = () => Object.values(layers)


### PR DESCRIPTION
This change adds a small button to improve the UX when it comes to changing layer names at is not obvious on first sight that the Enter-Button must be used to change a layer name.

<img width="247" alt="image" src="https://github.com/syncpoint/ODIN/assets/23622811/a8530c68-3cee-47f6-ae2c-3f8a395a3e67">
